### PR TITLE
🔧 update manifest to auto discover more walkingpad devices

### DIFF
--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -3,7 +3,43 @@
   "name": "Kingsmith WalkingPad",
   "bluetooth": [
     {
-      "local_name": "KS-ST-A1P"
+      "local_name": "DYNAMAX*"
+    },
+    {
+      "local_name": "KINGSMITH*"
+    },
+    {
+      "local_name": "KS-BL*"
+    },
+    {
+      "local_name": "KS-F0*"
+    },
+    {
+      "local_name": "KS-H*"
+    },
+    {
+      "local_name": "KS-MC*"
+    },
+    {
+      "local_name": "KS-NACH-*"
+    },
+    {
+      "local_name": "KS-NGCH-*"
+    },
+    {
+      "local_name": "KS-R1*"
+    },
+    {
+      "local_name": "KS-SC-*"
+    },
+    {
+      "local_name": "KS-ST-*"
+    },
+    {
+      "local_name": "KS-X21*"
+    },
+    {
+      "local_name": "WalkingPad"
     }
   ],
   "codeowners": [


### PR DESCRIPTION
The current version of the integration auto-detects very few WalkingPad models. 

The manifest file has been updated to auto-discover more models.
It should now discover the following models: K12 Pro, R1, R2, X21, X23, G1, C2, Dynamax running pad.

(assuming that these models can be properly controlled with the ph4-walkingpad) 