### PR TITLE
🌐 add english translations for sensor names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- upgrade homeassistant to 2024.3.3
+- add support for more WalkingPad models
+- upgrade homeassistant to 2025.2.5
 
 ### Fixed
 
 - warnings about invalid suggested_unit_of_measurement
+- add missing translations for sensor names
 
 ## [0.1.0] - 2024-03-29
 

--- a/custom_components/king_smith/translations/en.json
+++ b/custom_components/king_smith/translations/en.json
@@ -28,5 +28,27 @@
                 "title": "Manual configuration of a Walkingpad"
             }
         }
+    },
+    "entity": {
+        "sensor": {
+            "walkingpad_current_speed": {
+                "name": "Current speed"
+            },
+            "walkingpad_distance": {
+                "name": "Distance"
+            },
+            "walkingpad_duration_minutes": {
+                "name": "Duration (minutes)"
+            },
+            "walkingpad_duration_hours": {
+                "name": "Duration (hours)"
+            },
+            "walkingpad_duration_days": {
+                "name": "Duration (days)"
+            },
+            "walkingpad_steps": {
+                "name": "Steps"
+            }
+        }
     }
 }


### PR DESCRIPTION


WalkingPad sensor names are not translated, so their IDs are displayed instead.