### PR TITLE
🐛 fix error X is not a valid BeltState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - warnings about invalid suggested_unit_of_measurement
 - add missing translations for sensor names
+- handle unknown belt states
 
 ## [0.1.0] - 2024-03-29
 

--- a/custom_components/king_smith/const.py
+++ b/custom_components/king_smith/const.py
@@ -1,18 +1,20 @@
 """Constants for the walkingpad integration."""
 
-from enum import Enum, unique
+from enum import Enum, IntEnum, unique
 from typing import TypedDict
 
 DOMAIN = "king_smith"
 
 
 @unique
-class BeltState(Enum):
+class BeltState(IntEnum):
     """An enumeration of the possible belt states."""
 
     STOPPED = 0
     ACTIVE = 1
     STANDBY = 5
+    STARTING = 9
+    UNKNOWN = 1000
 
 
 @unique

--- a/custom_components/king_smith/walkingpad.py
+++ b/custom_components/king_smith/walkingpad.py
@@ -48,7 +48,7 @@ class WalkingPad:
         """Update current state."""
 
         status: WalkingPadStatus = {
-            "belt_state": BeltState(data.belt_state),
+            "belt_state": BeltState(data.belt_state) if data.belt_state in iter(BeltState) else BeltState.UNKNOWN,
             "speed": data.speed / 10,
             "mode": WalkingPadMode(data.manual_mode),
             "session_distance": data.dist * 10,


### PR DESCRIPTION
Occasionally, a "X is not a valid BeltState" exception appears in the logs, like this one:

```
2025-02-22 23:45:17.422 ERROR (MainThread) [ph4_walkingpad.pad] Exception in processing msg [f8, a2, 08, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 03, 00, ae, fd]: 8 is not a valid BeltState
Traceback (most recent call last):
  File "/home/vscode/.local/lib/python3.13/site-packages/ph4_walkingpad/pad.py", line 262, in notif_handler
    self.handler_cur_status(sender, m)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/workspaces/hass-walkingpad/custom_components/king_smith/walkingpad.py", line 51, in _on_status_update
    "belt_state": BeltState(data.belt_state),
                  ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/enum.py", line 726, in __call__
    return cls.__new__(cls, value)
           ~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/enum.py", line 1199, in __new__
    raise ve_exc
ValueError: 8 is not a valid BeltState
```

Not all the belt state values are known, so some are not declared in the BeltState enum.  This is what caused the error.
All unexpected values are now considered as Unknown.

If anyone knows what the values 7 and 8 (or any other value not declared in the BeltState enum) returned by WalkingPad for belt_state correspond to, I'd love to know!
