### PR TITLE
🐛 fix error cannot import name discover from bleak

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
+    "dockerFile": "./Dockerfile",
     "name": "ludeeus/integration_blueprint",
-    "image": "mcr.microsoft.com/devcontainers/python:3.13",
     "runArgs": [
         "-v/run/dbus:/run/dbus:ro",
         "--security-opt",
@@ -43,7 +43,8 @@
                     "--profile",
                     "black"
                 ],
-                "python.pythonPath": "/usr/bin/python3",
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
+                "python.pythonPath": "/usr/local/bin/python",
                 "python.analysis.autoSearchPaths": false,
                 "python.linting.pylintEnabled": true,
                 "python.linting.enabled": true,
@@ -58,6 +59,19 @@
     },
     "remoteUser": "vscode",
     "features": {
-        "ghcr.io/devcontainers/features/rust:1": {}
+        "ghcr.io/devcontainers/features/rust:1": {},
+        "ghcr.io/devcontainers/features/common-utils:2":{
+            "installZsh": "true",
+            "username": "vscode",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "true"
+        },
+        "ghcr.io/devcontainers/features/python:1": "none",
+        "ghcr.io/devcontainers/features/node:1": "none",
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- upgrade homeassistant to 2025.8.0
+- upgrade ph4-walkingpad to 1.0.2
+
+### Fixed
+
+- error when using this integration with latest versions of bleak
+
 ## [0.2.0] - 2025-02-23
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# This Dockerfile is a copy of https://github.com/devcontainers/images/blob/main/src/python/.devcontainer/Dockerfile with a hardcoded variant, since the devcontainer is not yet available for python 3.13.2
+
+FROM python:3.13.2
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
+    && apt-get purge -y imagemagick imagemagick-6-common 
+
+# Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897 and https://github.com/advisories/GHSA-2mqj-m65w-jghx
+# They are installed by the base image (python) which does not have the patch.
+RUN python3 -m pip install --upgrade \
+    setuptools==78.1.1 \
+    gitpython==3.1.41

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -54,7 +54,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/madmatah/hass-walkingpad/issues",
   "requirements": [
-    "ph4-walkingpad==0.0.7"
+    "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
   "version": "0.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.9.0
-homeassistant==2025.2.3
+homeassistant==2025.8.0
 pip==25.0.1
 ruff==0.9.6
-ph4-walkingpad==0.0.7
+ph4-walkingpad==1.0.2


### PR DESCRIPTION
An error occurs with latest versions of Home Assistant : 
`cannot import name 'discover' from 'bleak'`

The ph4_walkingpad 0.0.7 dependency was not compatible bleak version used by latest hass releases.

It has been updated to version 1.0.2

Fixes #72 