### PR TITLE
feat: Add FTMS BLE protocol support for KingSmith KS-HD-* treadmills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   release:
     types:
       - "published"
+      - "created"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.4.14)"
+        required: true
+        type: "string"
 
 permissions: {}
 
@@ -14,22 +21,41 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: "Resolve target tag"
+        id: "tag"
+        shell: "bash"
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${{ github.event.release.tag_name }}"
+          fi
+          # Strip leading "v" so manifest.json gets a clean semver string
+          # (HACS/HA expect "0.4.14", not "v0.4.14").
+          version="${tag#v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: "Checkout the repository"
         uses: "actions/checkout@v4.2.2"
+        with:
+          ref: "${{ steps.tag.outputs.tag }}"
 
       - name: "Adjust version number"
         shell: "bash"
         run: |
-          yq -i -o json '.version="${{ github.event.release.tag_name }}"' \
+          yq -i -o json '.version="${{ steps.tag.outputs.version }}"' \
             "${{ github.workspace }}/custom_components/king_smith/manifest.json"
 
       - name: "ZIP the integration directory"
         shell: "bash"
         run: |
           cd "${{ github.workspace }}/custom_components/king_smith"
-          zip king_smith.zip -r ./
+          # Exclude any local Python build artefacts so the zip is reproducible
+          zip -r king_smith.zip ./ -x '*.pyc' '*__pycache__*'
 
       - name: "Upload the ZIP file to the release"
         uses: softprops/action-gh-release@v2.2.1
         with:
+          tag_name: "${{ steps.tag.outputs.tag }}"
           files: ${{ github.workspace }}/custom_components/king_smith/king_smith.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-05-05
+
+### Changed
+
+- The **Stay connected** toggle is now strictly user-controlled. Pressing
+  the **Belt** switch (in either Manual or Auto mode) no longer flips
+  Stay-connected on or off as a side effect; whatever value the user has
+  set is preserved across belt start/stop. Removes the deferred-disconnect
+  plumbing that was used to "borrow and return" the toggle for the
+  duration of a walk.
+
+  If you have Stay-connected **off** and you start the belt, the library
+  will connect just long enough to send the start command and disconnect
+  immediately afterwards — the belt keeps running, but live sensors stay
+  stale until you re-enable Stay-connected.
+
 ## [0.4.4] - 2026-05-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-04
+
+### Fixed
+
+- pressing the belt **Stop** switch no longer drops the BLE connection
+  and silently flips the **Stay connected** toggle off when the user
+  has opted in to a persistent connection. The deferred-disconnect now
+  only fires when the belt switch had to flip `stay_connected` on for
+  the duration of the walk (i.e. it was off beforehand).
+
 ## [0.4.1] - 2026-05-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-05-05
+
+### Changed
+
+- When **Stay connected** is OFF, the BLE link is now held for **5 seconds
+  after the last action** before being dropped, instead of disconnecting
+  immediately after every command. This prevents connect/disconnect churn
+  when issuing a burst of actions in quick succession (e.g. start belt
+  then set speed, or set speed multiple times). Each new action resets
+  the 5 s timer; the link is dropped once the timer expires with no new
+  activity.
+
 ## [0.4.5] - 2026-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-04
+
+### Fixed
+
+- speed control on KingSmith MC-21 (and other models exposing the
+  vendor pre-amble characteristic) — bumps `walkingpad-controller`
+  to 0.4.1, which writes the required pre-amble before each FTMS
+  Control Point command and tolerates `REQUEST_CONTROL` rejection.
+  See [walkingpad-controller#1](https://github.com/mcdax/walkingpad-controller/issues/1).
+
 ## [0.3.0] - 2025-11-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-05-05
+
+### Fixed
+
+- **Belt switch lagged behind state changes.** After dragging the
+  speed slider, "Zustand" updated promptly but the **Belt** toggle
+  stayed in the wrong position for tens of seconds before flipping.
+  Cause: the belt-switch entity wasn't subscribed to coordinator
+  updates and was relying on HA's default polling. It now subscribes
+  to coordinator notifications (the same mechanism the **Zustand**
+  and **Verbunden** entities already used) and re-evaluates `is_on`
+  immediately on every status update.
+
 ## [0.4.8] - 2026-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,67 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-05-05
+
+### Fixed
+
+- **Speed slider now works while disconnected.** With Stay-connected
+  off and the belt stopped, dragging the slider previously did nothing
+  — HA gated the service call on the entity's "available" flag, which
+  was tied to the BLE link. The slider now stays available, the
+  underlying library connects-and-issues, and the belt starts at the
+  requested speed. (Bug #9 in the audit.)
+- **Belt switch entity_id is no longer mode-locked.** Earlier, the
+  manual-mode and auto-mode switch classes shared one `unique_id` but
+  used different `translation_key`s, so the entity_id froze to
+  whichever class was first registered. Both variants now use the
+  unified `walkingpad_belt` translation_key; existing installs are
+  migrated. (Bug #2.)
+- **Belt switch goes unavailable when disconnected.** Matches the
+  sensor behavior; previously the switch silently no-op'd if you
+  tapped it while the link was down. (Bug #11.)
+- **Stale 2ADA event on every reconnect.** Fixed in
+  walkingpad-controller 0.4.5 — KingSmith firmware replays its
+  current Fitness Machine Status when the CCCD is enabled, which
+  flipped `last_fm_event` to a misleading historical value within a
+  second of every connect. The first 2ADA event after subscribe is
+  now skipped. (Bug #5.)
+
+### Changed
+
+- **Canonical English entity_ids on every install.** New entities now
+  pin their entity_id to a stable English slug derived from the
+  unique_id key, rather than letting HA derive it from the localized
+  friendly_name. Existing installs are migrated on integration
+  reload — entities like `sensor.state`, `switch.stay_connected`,
+  `number.speed`, and `sensor.walkingpad_kalorienrate` are renamed to
+  `sensor.walkingpad_state`, `switch.walkingpad_stay_connected`,
+  `number.walkingpad_speed`, `sensor.walkingpad_calories_per_hour`,
+  and so on.
+
+  **Action required:** any automations, scripts, or dashboards
+  referencing the old entity_ids need to be updated. The migration
+  log will list each rename in the HA logs at integration reload, so
+  you can grep for "Migrating entity_id" to see exactly what changed.
+- **Enum sensor states are now translated.** `Mode`, `State`,
+  `Training status`, `Last FTMS event`, and `Protocol` sensors now
+  show user-readable values in the UI's locale (English/German)
+  instead of raw snake_case identifiers. (Bug #4 / #8.)
+- Bumps `walkingpad-controller` to **0.4.5**.
+
+### Known limitations
+
+- On KS-HD-Z1D (and likely other KS-HD-* models), the `Last FTMS
+  event` sensor only captures **start** and **stop** events. The
+  device's firmware does not emit `target_speed_changed` 2ADA events
+  when speed is changed via the Control Point — the new speed shows
+  up only via the live `Treadmill Data` notifications, which drive
+  `Current speed` directly. (Bug #6.)
+- Rapid switch toggles within roughly one second (e.g. tapping the
+  Belt switch off+on in quick succession) may lose the second
+  command. Wait for the device to reach the first state before
+  issuing the next. (Bug #10 — work in progress.)
+
 ## [0.4.7] - 2026-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-05-04
+
+### Added
+
+- device card now shows the **firmware version** (read from FTMS Software
+  Revision String 0x2A28) and the BLE-advertised model name. Powered by
+  the new properties in `walkingpad-controller` 0.4.3.
+
+### Changed
+
+- bumps `walkingpad-controller` to **0.4.3**, which (a) adds eager FTMS
+  detection for the MC-21 family (`KS-MC21-*`, `KS-SMC21C-*`,
+  `ZP-ZEALR1-*`), (b) staggers the FTMS CCCD subscriptions to match KS
+  Fit's connect timing, (c) acknowledges Control Point commands via
+  Fitness Machine Status events on the vendor pre-amble path, and
+  (d) subscribes to Training Status (`0x2AD3`).
+
 ## [0.4.2] - 2026-05-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.10] - 2026-05-05
+
+### Fixed
+
+- **Belt toggle now starts the belt directly from a disconnected state.**
+  Previously the toggle went unavailable when the BLE link was down,
+  forcing the user to first re-enable Stay-connected (or use the speed
+  slider) before they could start a walk. The toggle now stays
+  available; tapping it triggers the same connect-and-issue sequence
+  the slider already used.
+- **Auto-reconnect on BLE drops with backoff.** KingSmith firmware
+  occasionally drops the link mid-command (e.g. during a cold-start
+  `START_OR_RESUME`) and then refuses new connections for tens of
+  seconds. The previous single +1 s reconnect attempt was getting
+  overrun by the library's own internal retry and never fired again,
+  leaving the integration stuck for minutes until the next polling tick
+  recovered. The disconnect callback now schedules attempts at +3 s,
+  +10 s, +30 s, and +60 s, covering the firmware's full recovery
+  window.
+- **Stay-connected truly keeps the link alive.** When Stay-connected
+  was ON and the user navigated to a different HA page, the coordinator
+  was disconnecting the BLE link as soon as listeners dropped to zero
+  (the `_unschedule_refresh` handler unconditionally tore down the
+  link). Returning to the device page would then show stale "unavailable"
+  state until reconnect kicked in. The disconnect on listener-drop is
+  now skipped when Stay-connected is ON.
+
 ## [0.4.9] - 2026-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-05-05
+
+### Added
+
+- **Connected** binary sensor (`binary_sensor.walkingpad_connected`,
+  `device_class=connectivity`, diagnostic) showing whether HA currently
+  has an active BLE link to the treadmill.
+- **Calorie rate** sensor (kcal/h, FTMS only).
+- **Heart rate** sensor (bpm, FTMS only). Reports as unavailable when
+  no HR strap is paired with the treadmill — FTMS reports `0` in that
+  case, which would otherwise mislead.
+- **Protocol** sensor (enum: `ftms` / `wilink` / `unknown`, diagnostic).
+- **Min speed**, **Max speed**, **Speed increment** sensors (km/h,
+  diagnostic) — exposes the device-capability values that already drive
+  the speed slider, so they're available for use in templates and
+  automations.
+- **Firmware version** sensor (string, FTMS-only, diagnostic) —
+  populated from the FTMS Software Revision String. Also continues to
+  appear as `sw_version` on the device card.
+
+### Fixed
+
+- The library's BLE-disconnect callback was previously not propagated
+  to the coordinator, meaning entities (sensor `available`, switches
+  `is_on`, the new connected binary sensor) didn't react to mid-session
+  link drops promptly. The disconnect now flows through to all
+  registered listeners.
+
+### Changed
+
+- Internal: `WalkingPadSensorEntityDescription.value_fn` now receives
+  the coordinator instead of the bare status dict, so static device-
+  info sensors and dynamic status sensors share the same description
+  class. New `static=True` flag marks sensors whose value comes from
+  device capabilities and stays available even with BLE down.
+
 ## [0.4.6] - 2026-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-05-04
+
+### Added
+
+- Two new diagnostic sensors on FTMS devices, populated from the Training
+  Status (`0x2AD3`) and Fitness Machine Status (`0x2ADA`) notifications
+  the library subscribes to:
+  - **Training status** — Bluetooth SIG FTMS standard enum: `idle`,
+    `warming_up`, `low_intensity_interval`, `high_intensity_interval`,
+    `recovery_interval`, `cool_down`, `manual_mode`, `pre_workout`,
+    `post_workout`, etc.
+  - **Last FTMS event** — opcode of the most recent state-change event:
+    `started_or_resumed`, `stopped_or_paused`, `target_speed_changed`,
+    `target_inclination_changed`, etc.
+
+### Changed
+
+- Bumps `walkingpad-controller` to **0.4.4**, which extends
+  `TreadmillStatus` with `training_status` and `last_fm_event` fields
+  and fires the status callback whenever they change.
+
 ## [0.4.3] - 2026-05-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.15] - 2026-05-10
+
+### Fixed
+
+- **Stop button now lives under Steuerelemente / Controls.** It was
+  previously categorised as a diagnostic/config entity, so it ended up
+  buried under Konfiguration on the device card. The Stop button is a
+  primary user-facing control and belongs alongside the belt switch
+  and speed slider.
+
 ## [0.4.14] - 2026-05-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.16] - 2026-05-10
+
+### Changed
+
+- Bumps `walkingpad-controller` to **0.4.11**, which switches the FTMS
+  connect path to `bleak_retry_connector.establish_connection()`.
+  Addresses the long-standing `BleakClient.connect() called without
+  bleak-retry-connector` warning and substantially improves connection
+  reliability on ESPHome BT-proxy setups (no more
+  `ESP_GATT_CONN_FAIL_ESTABLISH` floods on marginal RSSI).
+
 ## [0.4.15] - 2026-05-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.12] - 2026-05-10
+
+### Changed
+
+- **Belt toggle now pauses instead of fully stopping.** Previously
+  toggling the belt switch off ended the session and zeroed the
+  counters; toggling on then started a fresh session. This didn't
+  match what the phone app and the physical remote do, where pressing
+  stop pauses the session and counters carry over to the next start.
+  The toggle now sends FTMS PAUSE (`STOP_OR_PAUSE` opcode `0x08` with
+  PAUSE param `0x02`), via the new `WalkingPadController.pause()`
+  exposed in `walkingpad-controller` 0.4.7. The hard-stop path
+  (`stop_belt()`) is still available on the WalkingPad wrapper for
+  explicit session resets.
+  Refs [walkingpad-controller#2](https://github.com/mcdax/walkingpad-controller/issues/2).
+
 ## [0.4.11] - 2026-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.13] - 2026-05-10
+
+### Added
+
+- **`paused` state on the `walkingpad_state` sensor.** When the user
+  toggles the belt off (which now sends FTMS PAUSE — see 0.4.12), the
+  state sensor reports `paused` instead of `stopped`, so dashboards
+  and automations can distinguish "session paused, will resume" from
+  "session ended, counters reset on next start". Pulls in
+  [walkingpad-controller 0.4.8](https://github.com/mcdax/walkingpad-controller/releases/tag/v0.4.8)
+  which adds `BeltState.PAUSED` and tracks it from FTMS Status events.
+- **Stop button entity** (`button.walkingpad_stop_session`) that sends
+  the hard-stop variant — full session end with counters reset. Useful
+  when you actually want to start over instead of resume. Available
+  only when the BLE link is up; gated by remote-control like the belt
+  switch. Refs [walkingpad-controller#2](https://github.com/mcdax/walkingpad-controller/issues/2).
+
 ## [0.4.12] - 2026-05-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.14] - 2026-05-10
+
+### Fixed
+
+- **Reconnect task and BLE callbacks no longer leak across integration
+  reloads.** `async_unload_entry` now calls
+  `coordinator.async_shutdown()` before clearing `hass.data` — without
+  this, each reload added another listener and the duplicate-event
+  firing we eliminated in 0.4.10 came back.
+- **Reconnect-task drain on disconnect.** Cancelling the reconnect
+  loop and immediately running the disconnect raced against the
+  in-flight `walkingpad.connect()`, both touching
+  `_connection_status`. The cancel now also awaits the loop so the
+  state is settled before disconnect runs.
+- **Firmware version now appears on the device card.** Entities
+  snapshot `firmware_version` into their `DeviceInfo` at construction
+  time, but the library only reads it on connect, so the card stayed
+  empty. The coordinator now pushes the value into the device
+  registry on the first status update where it's known.
+- **Defensive entity-id migration (issue #2).** A failed migration
+  (e.g. an orphan from a previous registration occupying the canonical
+  entity_id) no longer kills integration setup; it logs a warning and
+  the integration loads.
+- **Stop button** entity's coordinator-update handler is now
+  `@callback`-decorated, matching the other entities and silencing
+  HA's thread-safety warnings.
+- Drop deprecated `CONNECTION_CLASS` from the config flow.
+
+### Changed
+
+- Bumps `walkingpad-controller` to **0.4.10**, which brings:
+  - WiLink: surface unilateral disconnects to upper layers (legacy
+    devices' disconnect callback never fired before).
+  - `WalkingPadController.disconnect()` no longer skips teardown when
+    the cached `_connected` bit drifted from the live backend state.
+
 ## [0.4.13] - 2026-05-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.11] - 2026-05-05
+
+### Fixed
+
+- Connection stability on marginal-signal hardware. Pulls in
+  `walkingpad-controller` 0.4.6, which removes the Training Status
+  CCCD subscription from the connect critical path. Measured impact
+  on KS-HD-Z1D at -83 dBm RSSI: 20-second idle survival rate went
+  from 0/5 to 4/5. See
+  [walkingpad-controller v0.4.6](https://github.com/mcdax/walkingpad-controller/releases/tag/v0.4.6)
+  for the bisection that motivated the change.
+
+### Removed
+
+- The `walkingpad_training_status` sensor was removed because the
+  underlying Training Status (0x2AD3) subscription is no longer made
+  on connect (see above). Existing installations may see the entity
+  as "unavailable" — it can be deleted from the entity registry.
+  The field is still passed through coord data so a future opt-in
+  re-subscribe could revive the sensor without further coord changes.
+
 ## [0.4.10] - 2026-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-16
+
+### Added
+
+- **Sperax P3 Max (wi-linktech WLT6200) support.** Adds a second protocol
+  alongside FTMS/WiLink: connect, speed control (up to 12 km/h), start /
+  stop / pause, incline (0-10), and vibration control, plus decoding of the
+  device's status frames (speed, distance, duration, steps, incline,
+  vibration). Incline and vibration controls and read-only sensors appear
+  only on Sperax devices. Requires `walkingpad-controller` 0.5.0.
+- **Reconnect button.** A manual "Reconnect" button forces an immediate
+  BLE reconnect attempt instead of waiting out the reconnect loop's
+  backoff (which settles at 30 s between tries once the treadmill has
+  been off for a while). Pressing it cancels the in-flight backoff sleep,
+  connects right away, and — if that fails and Stay-connected is on —
+  re-arms the loop so it keeps retrying. Enabled only while disconnected;
+  greys out once connected. Lives under Konfiguration / Diagnostics next
+  to the Connected sensor. Resolves #4.
+- **Speed slider unit conversion.** The speed adjustment now carries the
+  SPEED device class, so Home Assistant displays it in the user's preferred
+  unit (e.g. mph) and converts the set value back to km/h before sending it
+  to the belt — matching the "Current speed" sensor. Note the whole scale is
+  converted, so the 0.5 km/h step lands on non-round mph values. Resolves #5.
+
 ## [0.4.16] - 2026-05-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-16
+
+### Fixed
+
+- **Sperax name detection no longer misroutes FTMS pads.** Bumps
+  `walkingpad-controller` to 0.5.1, which limits the Sperax vendor-protocol
+  name match to the P3 Max (`SPERAX_P3MAX`) instead of any `SPERAX_` name.
+  Sperax-branded pads that speak FTMS (e.g. the RM-01) are handled as FTMS
+  again instead of being pushed onto the wrong protocol.
+
+### Changed
+
+- README updated for the v0.5.0 features (Sperax P3 Max support, Reconnect
+  button, incline/vibration controls, unit-aware speed slider) and corrected
+  where it was stale (Stay Connected is always created; no auto-toggle).
+
 ## [0.5.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 [![GitHub Activity][commits-shield]][commits]
 [![License][license-shield]](LICENSE)
 
+Home Assistant custom integration for KingSmith WalkingPad treadmills. Supports both the standard **FTMS** (Fitness Machine Service) BLE protocol and the legacy **WiLink** protocol.
+
+> This is a fork of [madmatah/hass-walkingpad](https://github.com/madmatah/hass-walkingpad) that adds FTMS protocol support via the [walkingpad-controller](https://github.com/mcdax/walkingpad-controller) library.
 
 **This integration will set up the following platforms.**
 
 Platform | Description
 -- | --
-`sensor` | WalkingPad usage metrics.
-`switch` | Belt control (requires remote control to be enabled).
+`sensor` | WalkingPad usage metrics (speed, distance, duration, steps, calories).
+`switch` | Belt control and stay-connected toggle (requires remote control to be enabled).
 `number` | Speed control in manual mode (requires remote control to be enabled).
 
 ## Installation
@@ -19,7 +22,7 @@ Platform | Description
 1. Open the HACS dashboard then click `Integrations`,
 1. Click the `3 dots menu` on the top right corner
 1. Click `Custom repository`
-1. Enter the repo url `https://github.com/madmatah/hass-walkingpad`
+1. Enter the repo url `https://github.com/mcdax/hass-walkingpad`
 1. Chose a the `Integration` category then **Submit**
 1. Click on the new `Kingsmith WalkingPad` repo
 1. Click on `Download` on the bottom right corner.
@@ -53,8 +56,6 @@ In this case, you will see a new discovered device in `Settings > Devices & Se
 Just click and configure and enter a friendly name for your device:
 
 ![Automatic config flow](./assets/images/bluetooth-config-flow.png)
-
-
 That's it!
 
 If your device is not detected, read the [FAQ](#my-walkingpad-device-is-not-detected) and try to use the Manual configuration mode.
@@ -66,8 +67,6 @@ In `Settings > Devices & Services`, click on `Add integration` and look for `Kin
 If you click on it, it will open the manual configuration form:
 
 ![Manual configuration](./assets/images/manual-config-flow.png)
-
-
 Enter your device MAC address in the "device" field and a friendly name in the "name" field.
 
 See the [FAQ](#my-walkingpad-device-is-not-detected) for more details.
@@ -96,7 +95,42 @@ When auto mode is selected:
 
 **Important safety note**: Always ensure the WalkingPad area is clear before using remote control features. Use these features at your own risk.
 
+### 4. Stay Connected switch
+
+When remote control is enabled, a **Stay Connected** switch entity is also created. This controls whether the BLE connection to the treadmill is kept open:
+
+- **ON** (connected): The integration maintains a BLE connection for real-time sensor updates. Required for remote control commands.
+- **OFF** (disconnected): The BLE connection is released. Sensors show stale data. Other Bluetooth clients (e.g. KS Fit app) can connect.
+
+**Auto-toggle behavior:** The integration automatically turns Stay Connected ON when you start the belt from Home Assistant, and OFF when the belt fully stops (after a deferred disconnect that waits for the belt to decelerate).
+
 <!---->
+
+## Supported protocols
+
+This integration supports two BLE communication protocols:
+
+### WiLink (legacy)
+
+The original protocol used by most KingSmith/WalkingPad devices, based on the `ph4-walkingpad` library. Communicates over BLE service `0xFE00`. This is the default for all devices except those matched below.
+
+### FTMS (Fitness Machine Service)
+
+Newer KingSmith treadmills (BLE name matching `KS-HD-*`) use the standard Bluetooth FTMS protocol (service `0x1826`) instead of the proprietary WiLink protocol. The integration auto-detects which protocol to use based on the device's BLE advertisement name.
+
+**FTMS-specific details:**
+- Speed range and increment are read from the device at connection time (e.g. 1.0-6.0 km/h in 0.1 km/h steps for the KS-Z1D)
+- Sensors: instantaneous speed, total distance, step count, elapsed time
+- Cold start requires the FTMS Start/Resume command before speed can be set
+- The integration handles BLE connection drops during cold start with automatic speed recovery on reconnect
+
+**Verified devices:**
+
+Device | BLE Name | Protocol
+-- | -- | --
+KS-Z1D | KS-HD-Z1D | FTMS
+
+If you have a KingSmith device that uses FTMS (or doesn't work with the legacy protocol), please [open an issue](https://github.com/mcdax/hass-walkingpad/issues) with your device model and BLE name.
 
 ## FAQ
 
@@ -128,7 +162,7 @@ It should open the manual configuration form. Enter the MAC address in the
 `Device` form field, any the name of your choice in the `Name` field.
 Click on `Submit` and cross your fingers!
 
-If it works, please open an issue here and tell me the Bluetooth name of your
+If it works, please [open an issue](https://github.com/mcdax/hass-walkingpad/issues) and tell me the Bluetooth name of your
 WalkingPad and which model it corresponds to. This will enable me to activate
 automatic detection for this model.
 
@@ -162,25 +196,24 @@ You need to have Bluez >= 5.63 installed on your host system.
 
 It should be OK in most case, but if your DBus socket is not
 in `/run/dbus`, you might have to tweak the .devcontainer.json (see `runArgs`).
-
-
 #### 4. Profit
 
 Then, you can run the devcontainer and start Home Assistant with `scripts/develop`.
 
 You might have a TLS error on the first run in the logs. Just restart the command and everything should be fine, your bluetooth adapter should be detected by Home Assistant.
 
-
 ## Acknowledgements
 
-This project uses [ph4-walkingpad](https://github.com/ph4r05/ph4-walkingpad) library to control the WalkingPad device. Thanks [@ph4r05](https://github.com/ph4r05)!
+This project is a fork of [madmatah/hass-walkingpad](https://github.com/madmatah/hass-walkingpad), which uses [ph4-walkingpad](https://github.com/ph4r05/ph4-walkingpad) for legacy WiLink protocol support. Thanks [@madmatah](https://github.com/madmatah) and [@ph4r05](https://github.com/ph4r05)!
 
 This project takes inspiration and code from [@indiefan](https://github.com/indiefan)'s [king smith](https://github.com/indiefan/king_smith) custom integration.
 
+FTMS protocol support is provided by the [walkingpad-controller](https://github.com/mcdax/walkingpad-controller) library.
+
 ***
 
-[commits-shield]: https://img.shields.io/github/commit-activity/y/madmatah/hass-walkingpad.svg?style=for-the-badge
-[commits]: https://github.com/madmatah/hass-walkingpad/commits/main
-[license-shield]: https://img.shields.io/github/license/madmatah/hass-walkingpad.svg?style=for-the-badge
-[releases-shield]: https://img.shields.io/github/release/madmatah/hass-walkingpad.svg?style=for-the-badge
-[releases]: https://github.com/madmatah/hass-walkingpad/releases
+[commits-shield]: https://img.shields.io/github/commit-activity/y/mcdax/hass-walkingpad.svg?style=for-the-badge
+[commits]: https://github.com/mcdax/hass-walkingpad/commits/main
+[license-shield]: https://img.shields.io/github/license/mcdax/hass-walkingpad.svg?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/release/mcdax/hass-walkingpad.svg?style=for-the-badge
+[releases]: https://github.com/mcdax/hass-walkingpad/releases

--- a/README.md
+++ b/README.md
@@ -126,9 +126,10 @@ Newer KingSmith treadmills (BLE name matching `KS-HD-*`) use the standard Blueto
 
 **Verified devices:**
 
-Device | BLE Name | Protocol
+Brand | Device | BLE Name | Protocol
 -- | -- | --
-KS-Z1D | KS-HD-Z1D | FTMS
+KingSmith | KS-Z1D | KS-HD-Z1D | FTMS |
+Sperax | RM-01| SPERAX_RM-01_****** | FTMS
 
 If you have a KingSmith device that uses FTMS (or doesn't work with the legacy protocol), please [open an issue](https://github.com/mcdax/hass-walkingpad/issues) with your device model and BLE name.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Newer KingSmith treadmills (BLE name matching `KS-HD-*`) use the standard Blueto
 **Verified devices:**
 
 Brand | Device | BLE Name | Protocol
--- | -- | --
+-- | -- | -- | --
 KingSmith | KS-Z1D | KS-HD-Z1D | FTMS |
 Sperax | RM-01| SPERAX_RM-01_****** | FTMS
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@
 [![GitHub Activity][commits-shield]][commits]
 [![License][license-shield]](LICENSE)
 
-Home Assistant custom integration for KingSmith WalkingPad treadmills. Supports both the standard **FTMS** (Fitness Machine Service) BLE protocol and the legacy **WiLink** protocol.
+Home Assistant custom integration for KingSmith WalkingPad treadmills. Supports the standard **FTMS** (Fitness Machine Service) BLE protocol, the legacy **WiLink** protocol, and the **Sperax** (wi-linktech WLT6200) protocol used by the Sperax P3 Max.
 
-> This is a fork of [madmatah/hass-walkingpad](https://github.com/madmatah/hass-walkingpad) that adds FTMS protocol support via the [walkingpad-controller](https://github.com/mcdax/walkingpad-controller) library.
+> This is a fork of [madmatah/hass-walkingpad](https://github.com/madmatah/hass-walkingpad) that adds FTMS and Sperax protocol support via the [walkingpad-controller](https://github.com/mcdax/walkingpad-controller) library.
 
 **This integration will set up the following platforms.**
 
 Platform | Description
 -- | --
-`sensor` | WalkingPad usage metrics (speed, distance, duration, steps, calories).
-`switch` | Belt control and stay-connected toggle (requires remote control to be enabled).
-`number` | Speed control in manual mode (requires remote control to be enabled).
+`sensor` | WalkingPad usage metrics (speed, distance, duration, steps, calories, and — on Sperax devices — incline and vibration level).
+`binary_sensor` | Connection status.
+`switch` | Stay-connected toggle (always available), plus belt control when remote control is enabled.
+`number` | Speed control in manual mode, plus incline and vibration on Sperax devices (require remote control to be enabled).
+`button` | Reconnect (always available), plus a Stop-session button when remote control is enabled.
 
 ## Installation
 
@@ -85,7 +87,7 @@ Once enabled, you need to select a preferred mode that determines how the remote
 
 When manual mode is selected:
 - A **switch entity** is created that directly controls the belt start/stop. Turning the switch on starts the belt, turning it off stops it.
-- A **number entity** is created for speed control, allowing you to set the belt speed between 0.5 and 6.0 km/h (in increments of 0.1 km/h). The speed can only be adjusted when the belt is active or starting.
+- A **number entity** is created for speed control. The available range and step are read from the device at connection time (for example up to 12 km/h on the Sperax P3 Max), and the slider follows your Home Assistant unit setting (so it can display mph and convert back to km/h for the belt). On FTMS and Sperax devices you can set a speed even while stopped or disconnected — the integration connects and starts the belt as needed. On legacy WiLink devices the speed can only be adjusted while the belt is active or starting.
 
 #### Auto mode
 
@@ -97,18 +99,27 @@ When auto mode is selected:
 
 ### 4. Stay Connected switch
 
-When remote control is enabled, a **Stay Connected** switch entity is also created. This controls whether the BLE connection to the treadmill is kept open:
+A **Stay Connected** switch entity is always created (independently of remote control). It controls whether the BLE connection to the treadmill is kept open:
 
 - **ON** (connected): The integration maintains a BLE connection for real-time sensor updates. Required for remote control commands.
 - **OFF** (disconnected): The BLE connection is released. Sensors show stale data. Other Bluetooth clients (e.g. KS Fit app) can connect.
 
-**Auto-toggle behavior:** The integration automatically turns Stay Connected ON when you start the belt from Home Assistant, and OFF when the belt fully stops (after a deferred disconnect that waits for the belt to decelerate).
+Stay Connected stays under your control — the integration does not flip it automatically when you start or stop the belt. With it off, belt and speed commands still work: the integration briefly connects to send the command, then releases the link again.
+
+### 5. Buttons
+
+- **Reconnect** (always available): forces an immediate BLE reconnect instead of waiting out the automatic retry backoff, which can take up to 30 seconds once the treadmill has been off for a while. It is only enabled while the device is disconnected and lives under Konfiguration / Diagnostics.
+- **Stop** (when remote control is enabled): ends the current session and resets the counters. Different from the belt switch, which pauses and keeps the counters.
+
+### 6. Incline and vibration (Sperax P3 Max)
+
+On Sperax devices, two extra **number entities** are created when remote control is enabled: incline (0–10) and vibration (0 = off, 1–4). Matching read-only sensors show the current incline and vibration level. On the P3 Max the belt and the vibration motor are mutually exclusive — turning vibration on stops the belt.
 
 <!---->
 
 ## Supported protocols
 
-This integration supports two BLE communication protocols:
+This integration supports three BLE communication protocols:
 
 ### WiLink (legacy)
 
@@ -124,12 +135,19 @@ Newer KingSmith treadmills (BLE name matching `KS-HD-*`) use the standard Blueto
 - Cold start requires the FTMS Start/Resume command before speed can be set
 - The integration handles BLE connection drops during cold start with automatic speed recovery on reconnect
 
+### Sperax (wi-linktech WLT6200)
+
+The Sperax P3 Max uses a vendor-specific protocol over BLE service `0xFFF0` rather than FTMS. It is detected from the BLE name `SPERAX_P3MAX`. In addition to the usual sensors, Sperax devices expose incline (0–10) and vibration (0–4) controls and sensors.
+
+Protocol detection is name-based first (with the prefixes above), and falls back to probing the device's BLE services when the name is not conclusive. That fallback is why a device such as the Sperax RM-01, whose name starts with `SPERAX_` but which speaks FTMS, is still handled as FTMS.
+
 **Verified devices:**
 
 Brand | Device | BLE Name | Protocol
 -- | -- | -- | --
 KingSmith | KS-Z1D | KS-HD-Z1D | FTMS |
 Sperax | RM-01| SPERAX_RM-01_****** | FTMS
+Sperax | P3 Max | SPERAX_P3MAX | Sperax
 
 If you have a KingSmith device that uses FTMS (or doesn't work with the legacy protocol), please [open an issue](https://github.com/mcdax/hass-walkingpad/issues) with your device model and BLE name.
 

--- a/custom_components/king_smith/__init__.py
+++ b/custom_components/king_smith/__init__.py
@@ -15,7 +15,12 @@ from .const import CONF_MAC, CONF_NAME, DOMAIN
 from .coordinator import WalkingPadCoordinator
 from .walkingpad import WalkingPad
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.NUMBER,
+]
 
 
 class WalkingPadIntegrationData(TypedDict):

--- a/custom_components/king_smith/__init__.py
+++ b/custom_components/king_smith/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 
 from .const import CONF_MAC, CONF_NAME, DOMAIN
 from .coordinator import WalkingPadCoordinator
@@ -64,6 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(f"Could not find Walkingpad with address {address}")
 
     name = entry.data.get(CONF_NAME) or DOMAIN
+    _async_migrate_entity_ids(hass, entry)
     walkingpad_device = WalkingPad(name, ble_device)
     coordinator = WalkingPadCoordinator(hass, walkingpad_device)
 
@@ -86,3 +88,92 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+# One-time entity_id migration. Earlier versions of this integration registered
+# entities with HA-auto-generated entity_ids derived from the localized
+# friendly_name, leading to inconsistent / collision-prone IDs like
+# `sensor.state`, `switch.stay_connected`, and `sensor.walkingpad_kalorienrate`
+# (German). New installs use `_attr_suggested_object_id` to land on canonical
+# English IDs from the start; this migration brings existing installs in line.
+#
+# Maps unique_id key → desired entity_id slug (no platform prefix).
+_ENTITY_ID_MIGRATIONS: dict[str, str] = {
+    "walkingpad_distance": "walkingpad_distance",
+    "walkingpad_duration": "walkingpad_duration",
+    "walkingpad_current_speed": "walkingpad_current_speed",
+    "walkingpad_state": "walkingpad_state",
+    "walkingpad_mode": "walkingpad_mode",
+    "walkingpad_steps": "walkingpad_steps",
+    "walkingpad_calories": "walkingpad_calories",
+    "walkingpad_calories_per_hour": "walkingpad_calories_per_hour",
+    "walkingpad_heart_rate": "walkingpad_heart_rate",
+    "walkingpad_training_status": "walkingpad_training_status",
+    "walkingpad_last_event": "walkingpad_last_event",
+    "walkingpad_firmware_version": "walkingpad_firmware_version",
+    "walkingpad_protocol": "walkingpad_protocol",
+    "walkingpad_min_speed": "walkingpad_min_speed",
+    "walkingpad_max_speed": "walkingpad_max_speed",
+    "walkingpad_speed_increment": "walkingpad_speed_increment",
+    "walkingpad_speed": "walkingpad_speed",
+    "walkingpad_belt_switch": "walkingpad_belt",
+    "walkingpad_stay_connected": "walkingpad_stay_connected",
+    "walkingpad_connected": "walkingpad_connected",
+}
+
+# Translation_key migrations: collapse the manual/auto belt switch variants
+# into a single `walkingpad_belt` so the friendly_name no longer carries a
+# misleading mode suffix when the user changes preferred_mode.
+_TRANSLATION_KEY_MIGRATIONS: dict[str, str] = {
+    "walkingpad_belt_switch": "walkingpad_belt",
+    "walkingpad_belt_switch_manual": "walkingpad_belt",
+    "walkingpad_belt_switch_auto": "walkingpad_belt",
+}
+
+
+def _async_migrate_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Bring legacy entity_ids and translation_keys onto the new canonical scheme."""
+    entity_registry = er.async_get(hass)
+    mac = entry.data.get(CONF_MAC)
+    if not mac:
+        return
+
+    entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    for ent in entries:
+        # Each unique_id is `{MAC}-{key}`. Pull the key.
+        if not ent.unique_id.startswith(f"{mac}-"):
+            continue
+        key = ent.unique_id[len(mac) + 1 :]
+
+        desired_slug = _ENTITY_ID_MIGRATIONS.get(key)
+        if desired_slug is None:
+            continue
+        desired_entity_id = f"{ent.domain}.{desired_slug}"
+
+        new_translation_key = _TRANSLATION_KEY_MIGRATIONS.get(
+            ent.translation_key or "", ent.translation_key
+        )
+
+        updates: dict[str, str] = {}
+        if (
+            ent.entity_id != desired_entity_id
+            and entity_registry.async_get(desired_entity_id) is None
+        ):
+            _LOGGER.info(
+                "Migrating entity_id %s -> %s", ent.entity_id, desired_entity_id
+            )
+            updates["new_entity_id"] = desired_entity_id
+        if (
+            new_translation_key is not None
+            and ent.translation_key != new_translation_key
+        ):
+            _LOGGER.info(
+                "Migrating translation_key on %s: %s -> %s",
+                ent.entity_id,
+                ent.translation_key,
+                new_translation_key,
+            )
+            updates["translation_key"] = new_translation_key
+
+        if updates:
+            entity_registry.async_update_entity(ent.entity_id, **updates)

--- a/custom_components/king_smith/__init__.py
+++ b/custom_components/king_smith/__init__.py
@@ -21,6 +21,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.NUMBER,
+    Platform.BUTTON,
 ]
 
 
@@ -35,13 +36,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Update options and reload platforms."""
-    await hass.config_entries.async_unload_platforms(
-        entry, [Platform.SWITCH, Platform.NUMBER]
-    )
-    await hass.config_entries.async_forward_entry_setups(
-        entry, [Platform.SWITCH, Platform.NUMBER]
-    )
+    """Update options and reload platforms.
+
+    The platforms reloaded here are the ones whose entity set depends on
+    options (specifically `remote_control_enabled`). The button platform
+    is in this list so the Stop button appears / disappears alongside
+    the belt switch when the user toggles remote-control.
+    """
+    reloadable_platforms = [Platform.SWITCH, Platform.NUMBER, Platform.BUTTON]
+    await hass.config_entries.async_unload_platforms(entry, reloadable_platforms)
+    await hass.config_entries.async_forward_entry_setups(entry, reloadable_platforms)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/king_smith/__init__.py
+++ b/custom_components/king_smith/__init__.py
@@ -89,7 +89,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        integration_data: WalkingPadIntegrationData | None = hass.data[DOMAIN].pop(
+            entry.entry_id, None
+        )
+        # Shut the coordinator down so its reconnect task and BLE
+        # disconnect callback don't leak across reloads — otherwise the
+        # next coordinator's events fire 2x, 3x, … per reload.
+        if integration_data is not None:
+            await integration_data["coordinator"].async_shutdown()
 
     return unload_ok
 
@@ -180,4 +187,15 @@ def _async_migrate_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
             updates["translation_key"] = new_translation_key
 
         if updates:
-            entity_registry.async_update_entity(ent.entity_id, **updates)
+            try:
+                entity_registry.async_update_entity(ent.entity_id, **updates)
+            except ValueError as err:
+                # An orphan from a previous registration of the same device
+                # may already occupy the canonical entity_id. Skipping the
+                # rename here keeps the integration loadable; the orphan can
+                # be cleaned up manually from Settings → Entities.
+                _LOGGER.warning(
+                    "Skipping entity_id migration for %s: %s",
+                    ent.entity_id,
+                    err,
+                )

--- a/custom_components/king_smith/binary_sensor.py
+++ b/custom_components/king_smith/binary_sensor.py
@@ -57,6 +57,7 @@ class WalkingPadConnectedBinarySensor(BinarySensorEntity):
         self._attr_unique_id = (
             f"{coordinator.walkingpad_device.mac}-{CONNECTED_KEY}"
         )
+        self._attr_suggested_object_id = CONNECTED_KEY
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
             name=coordinator.walkingpad_device.name,

--- a/custom_components/king_smith/binary_sensor.py
+++ b/custom_components/king_smith/binary_sensor.py
@@ -1,0 +1,94 @@
+"""WalkingPad binary-sensor support."""
+
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import WalkingPadIntegrationData
+from .const import DOMAIN
+from .coordinator import WalkingPadCoordinator
+
+
+CONNECTED_KEY = "walkingpad_connected"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the WalkingPad binary sensors."""
+
+    entry_data: WalkingPadIntegrationData = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry_data["coordinator"]
+
+    async_add_entities([WalkingPadConnectedBinarySensor(coordinator)])
+
+
+class WalkingPadConnectedBinarySensor(BinarySensorEntity):
+    """Reflects whether the BLE link to the WalkingPad is currently up.
+
+    Goes off in a few situations the user cares about:
+      * Stay-connected was turned off (and the 5 s idle window has elapsed)
+      * The treadmill dropped the link (weak signal, firmware quirk)
+      * The phone app is currently holding the link (BLE is single-client)
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    entity_description = BinarySensorEntityDescription(
+        key=CONNECTED_KEY,
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        translation_key=CONNECTED_KEY,
+    )
+
+    def __init__(self, coordinator: WalkingPadCoordinator) -> None:
+        """Initialize the binary sensor."""
+        self.coordinator = coordinator
+        self._attr_unique_id = (
+            f"{coordinator.walkingpad_device.mac}-{CONNECTED_KEY}"
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
+            name=coordinator.walkingpad_device.name,
+            manufacturer="KingSmith",
+            model=coordinator.walkingpad_device.name,
+            sw_version=coordinator.walkingpad_device.firmware_version or None,
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the BLE link is currently established."""
+        return self.coordinator.connected
+
+    @property
+    def available(self) -> bool:
+        """The connectivity sensor is always available — it has a meaningful
+        value (False) even when the link is down."""
+        return True
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to coordinator updates so we re-render on state changes.
+
+        The coordinator notifies its listeners on every status update *and*
+        on the library's disconnect callback (`_async_handle_disconnect`),
+        which is enough to track the BLE link state with negligible lag.
+        """
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_state_change)
+        )
+
+    @callback
+    def _handle_state_change(self) -> None:
+        """Re-render in response to coordinator updates."""
+        self.async_write_ha_state()

--- a/custom_components/king_smith/button.py
+++ b/custom_components/king_smith/button.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.button import (
     ButtonEntity,
     ButtonEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -68,11 +65,13 @@ class WalkingPadStopSessionButton(ButtonEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
 
+    # No entity_category — the Stop button is a primary user-facing control,
+    # so it lives in "Steuerelemente" / Controls alongside the belt switch
+    # and speed slider, not buried under "Konfiguration" / Diagnostics.
     entity_description = ButtonEntityDescription(
         key=STOP_SESSION_KEY,
         icon="mdi:stop",
         translation_key=STOP_SESSION_KEY,
-        entity_category=EntityCategory.CONFIG,
     )
 
     def __init__(self, coordinator: WalkingPadCoordinator) -> None:

--- a/custom_components/king_smith/button.py
+++ b/custom_components/king_smith/button.py
@@ -10,7 +10,7 @@ from homeassistant.components.button import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -107,6 +107,7 @@ class WalkingPadStopSessionButton(ButtonEntity):
             self.coordinator.async_add_listener(self._handle_state_change)
         )
 
+    @callback
     def _handle_state_change(self) -> None:
         """Re-render — picks up changes to `coordinator.connected`."""
         self.async_write_ha_state()

--- a/custom_components/king_smith/button.py
+++ b/custom_components/king_smith/button.py
@@ -1,0 +1,112 @@
+"""WalkingPad button support — currently a single Stop Session button."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.button import (
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import WalkingPadIntegrationData
+from .const import CONF_MAC, CONF_REMOTE_CONTROL_ENABLED, DOMAIN
+from .coordinator import WalkingPadCoordinator
+
+
+STOP_SESSION_KEY = "walkingpad_stop_session"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the WalkingPad button(s).
+
+    The Stop button is a hard reset — it ends the session and zeros the
+    counters (time, distance, calories, steps). Gated by
+    remote_control_enabled like the belt switch, since users who haven't
+    opted into remote control shouldn't see a "stop" they can't pair with
+    a "start".
+    """
+    entry_data: WalkingPadIntegrationData = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry_data["coordinator"]
+
+    if entry.options.get(CONF_REMOTE_CONTROL_ENABLED, False):
+        async_add_entities([WalkingPadStopSessionButton(coordinator)])
+        return
+
+    # Remote control was disabled — clean up the entity if it existed
+    # from a previous configuration.
+    entity_registry = er.async_get(hass)
+    mac_address = entry.data.get(CONF_MAC)
+    unique_id = f"{mac_address}-{STOP_SESSION_KEY}"
+    entity_id = entity_registry.async_get_entity_id("button", DOMAIN, unique_id)
+    if entity_id:
+        entity_registry.async_remove(entity_id)
+
+
+class WalkingPadStopSessionButton(ButtonEntity):
+    """Hard-stop the WalkingPad and reset the session counters.
+
+    Different from toggling the belt switch off — that path now sends
+    PAUSE (counters carry over). This button is the explicit "end session
+    and start over" action, matching what an end-of-workout button would
+    do on the phone app.
+
+    Only available while the BLE link is up. Pressing it while
+    disconnected wouldn't do anything useful (the lib would have to
+    reconnect first, which can take seconds and might race with the
+    user's next action).
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    entity_description = ButtonEntityDescription(
+        key=STOP_SESSION_KEY,
+        icon="mdi:stop",
+        translation_key=STOP_SESSION_KEY,
+        entity_category=EntityCategory.CONFIG,
+    )
+
+    def __init__(self, coordinator: WalkingPadCoordinator) -> None:
+        """Initialize the Stop button."""
+        self.coordinator = coordinator
+        self._attr_unique_id = (
+            f"{coordinator.walkingpad_device.mac}-{STOP_SESSION_KEY}"
+        )
+        self._attr_suggested_object_id = STOP_SESSION_KEY
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
+            name=coordinator.walkingpad_device.name,
+            manufacturer="KingSmith",
+            model=coordinator.walkingpad_device.name,
+            sw_version=coordinator.walkingpad_device.firmware_version or None,
+        )
+
+    @property
+    def available(self) -> bool:
+        """The button is only enabled when the BLE link is up."""
+        return self.coordinator.connected
+
+    async def async_press(self) -> None:
+        """Send a hard stop — full session end, counters reset."""
+        await self.coordinator.walkingpad_device.stop_belt()
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to coordinator updates so `available` re-renders on
+        connect / disconnect events."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_state_change)
+        )
+
+    def _handle_state_change(self) -> None:
+        """Re-render — picks up changes to `coordinator.connected`."""
+        self.async_write_ha_state()

--- a/custom_components/king_smith/button.py
+++ b/custom_components/king_smith/button.py
@@ -1,4 +1,4 @@
-"""WalkingPad button support — currently a single Stop Session button."""
+"""WalkingPad button support — Stop Session and Reconnect buttons."""
 
 from __future__ import annotations
 
@@ -12,12 +12,15 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from homeassistant.helpers.entity import EntityCategory
+
 from . import WalkingPadIntegrationData
 from .const import CONF_MAC, CONF_REMOTE_CONTROL_ENABLED, DOMAIN
 from .coordinator import WalkingPadCoordinator
 
 
 STOP_SESSION_KEY = "walkingpad_stop_session"
+RECONNECT_KEY = "walkingpad_reconnect"
 
 
 async def async_setup_entry(
@@ -33,6 +36,11 @@ async def async_setup_entry(
     """
     entry_data: WalkingPadIntegrationData = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
+
+    # The Reconnect button is always created — it's about connectivity, not
+    # belt control, so it isn't gated by remote_control (same reasoning as
+    # the Stay-connected switch).
+    async_add_entities([WalkingPadReconnectButton(coordinator)])
 
     if entry.options.get(CONF_REMOTE_CONTROL_ENABLED, False):
         async_add_entities([WalkingPadStopSessionButton(coordinator)])
@@ -97,6 +105,69 @@ class WalkingPadStopSessionButton(ButtonEntity):
     async def async_press(self) -> None:
         """Send a hard stop — full session end, counters reset."""
         await self.coordinator.walkingpad_device.stop_belt()
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to coordinator updates so `available` re-renders on
+        connect / disconnect events."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_state_change)
+        )
+
+    @callback
+    def _handle_state_change(self) -> None:
+        """Re-render — picks up changes to `coordinator.connected`."""
+        self.async_write_ha_state()
+
+
+class WalkingPadReconnectButton(ButtonEntity):
+    """Force an immediate BLE reconnect attempt.
+
+    Addresses the "reconnect takes a while / feels random" pain (issue #4):
+    when the treadmill has been off, HA's reconnect loop settles into a 30 s
+    backoff, so it can lag noticeably behind the user powering the belt on.
+    Pressing this button short-circuits that wait and connects right away —
+    the equivalent of the "reconnect" affordance in the KS Fit app.
+
+    Only enabled while the link is down; once connected there's nothing to
+    do, so the button greys out (the inverse of the Stop button).
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    # Connectivity housekeeping rather than a primary workout control, so it
+    # lives under "Konfiguration" / Diagnostics next to the Connected sensor.
+    entity_description = ButtonEntityDescription(
+        key=RECONNECT_KEY,
+        icon="mdi:bluetooth-connect",
+        translation_key=RECONNECT_KEY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    )
+
+    def __init__(self, coordinator: WalkingPadCoordinator) -> None:
+        """Initialize the Reconnect button."""
+        self.coordinator = coordinator
+        self._attr_unique_id = (
+            f"{coordinator.walkingpad_device.mac}-{RECONNECT_KEY}"
+        )
+        self._attr_suggested_object_id = RECONNECT_KEY
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
+            name=coordinator.walkingpad_device.name,
+            manufacturer="KingSmith",
+            model=coordinator.walkingpad_device.name,
+            sw_version=coordinator.walkingpad_device.firmware_version or None,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Only offer a reconnect while the link is down."""
+        return not self.coordinator.connected
+
+    async def async_press(self) -> None:
+        """Kick an immediate reconnect attempt."""
+        await self.coordinator.async_reconnect_now()
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to coordinator updates so `available` re-renders on

--- a/custom_components/king_smith/config_flow.py
+++ b/custom_components/king_smith/config_flow.py
@@ -152,7 +152,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(step_id="device", data_schema=schema)
 
         user_input[CONF_MAC] = self.discovered_device["address"]
-        await self.async_set_unique_id(self.discovered_device["address"])
+        await self.async_set_unique_id(dr.format_mac(self.discovered_device["address"]))
         self._abort_if_unique_id_configured()
 
         remote_control_data = user_input.get(CONF_REMOTE_CONTROL, {})

--- a/custom_components/king_smith/config_flow.py
+++ b/custom_components/king_smith/config_flow.py
@@ -73,7 +73,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for walkingpad."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     @staticmethod
     @callback

--- a/custom_components/king_smith/const.py
+++ b/custom_components/king_smith/const.py
@@ -1,7 +1,11 @@
 """Constants for the walkingpad integration."""
 
-from enum import Enum, IntEnum, unique
+from enum import Enum, unique
 from typing import Final, TypedDict
+
+# Re-export BeltState and ProtocolType from the library so that all
+# integration modules can continue importing them from .const.
+from walkingpad_controller import BeltState, ProtocolType
 
 DOMAIN = "king_smith"
 
@@ -12,17 +16,6 @@ CONF_MAC: Final = "mac"
 CONF_MODE: Final = "mode"
 CONF_NAME: Final = "name"
 CONF_PREFERRED_MODE: Final = "preferred_mode"
-
-
-@unique
-class BeltState(IntEnum):
-    """An enumeration of the possible belt states."""
-
-    STOPPED = 0
-    ACTIVE = 1
-    STANDBY = 5
-    STARTING = 9
-    UNKNOWN = 1000
 
 
 @unique
@@ -50,4 +43,5 @@ class WalkingPadStatus(TypedDict):
     session_running_time: int  # in seconds
     session_distance: int  # distance in meters
     session_steps: int
+    session_calories: int  # total energy in kcal (FTMS only)
     status_timestamp: float

--- a/custom_components/king_smith/const.py
+++ b/custom_components/king_smith/const.py
@@ -44,6 +44,8 @@ class WalkingPadStatus(TypedDict):
     session_distance: int  # distance in meters
     session_steps: int
     session_calories: int  # total energy in kcal (FTMS only)
+    session_calories_per_hour: int  # energy rate in kcal/h (FTMS only)
+    heart_rate: int  # bpm; 0 when no HR sensor is paired with the treadmill
     training_status: int  # FTMS Training Status (0x2AD3) code; 0 if unknown
     last_fm_event: int  # opcode of most recent FM Status (0x2ADA) event
     status_timestamp: float

--- a/custom_components/king_smith/const.py
+++ b/custom_components/king_smith/const.py
@@ -44,4 +44,46 @@ class WalkingPadStatus(TypedDict):
     session_distance: int  # distance in meters
     session_steps: int
     session_calories: int  # total energy in kcal (FTMS only)
+    training_status: int  # FTMS Training Status (0x2AD3) code; 0 if unknown
+    last_fm_event: int  # opcode of most recent FM Status (0x2ADA) event
     status_timestamp: float
+
+
+# FTMS Training Status enum names (Bluetooth SIG standard 0x2AD3, byte 1).
+# Used to expose human-readable values via a sensor.
+FTMS_TRAINING_STATUS_NAMES: Final = {
+    0x00: "other",
+    0x01: "idle",
+    0x02: "warming_up",
+    0x03: "low_intensity_interval",
+    0x04: "high_intensity_interval",
+    0x05: "recovery_interval",
+    0x06: "iso_metric",
+    0x07: "heart_rate_control",
+    0x08: "fitness_test",
+    0x09: "speed_out_of_control",
+    0x0A: "cool_down",
+    0x0B: "watt_control",
+    0x0C: "manual_mode",
+    0x0D: "pre_workout",
+    0x0E: "post_workout",
+}
+
+# Fitness Machine Status (0x2ADA) opcodes — most-recent event.
+FTMS_FM_EVENT_NAMES: Final = {
+    0x00: "none",
+    0x01: "reset",
+    0x02: "stopped_or_paused",
+    0x03: "stopped_by_safety_key",
+    0x04: "started_or_resumed",
+    0x05: "target_speed_changed",
+    0x06: "target_inclination_changed",
+    0x07: "target_resistance_changed",
+    0x08: "target_power_changed",
+    0x09: "target_heart_rate_changed",
+    0x0A: "target_expended_energy_changed",
+    0x0B: "target_time_changed",
+    0x14: "spin_down_status",
+    0x15: "target_cadence_changed",
+    0xFF: "control_permission_lost",
+}

--- a/custom_components/king_smith/const.py
+++ b/custom_components/king_smith/const.py
@@ -48,6 +48,8 @@ class WalkingPadStatus(TypedDict):
     heart_rate: int  # bpm; 0 when no HR sensor is paired with the treadmill
     training_status: int  # FTMS Training Status (0x2AD3) code; 0 if unknown
     last_fm_event: int  # opcode of most recent FM Status (0x2ADA) event
+    vibration_level: int  # vibration intensity 0-4 (Sperax/WLT6200 only)
+    incline: int  # incline level 0-10 (Sperax/WLT6200 only)
     status_timestamp: float
 
 

--- a/custom_components/king_smith/coordinator.py
+++ b/custom_components/king_smith/coordinator.py
@@ -20,6 +20,9 @@ STATUS_UPDATE_INTERVAL = timedelta(seconds=5)
 # The ph4_walkingpad has a 10s timeout in its connect method, you might have trouble if you set a smaller timeout here.
 STATUS_UPDATE_TIMEOUT_SECONDS = 11
 
+# How long to wait for the belt to fully stop before giving up and disconnecting.
+DEFERRED_DISCONNECT_TIMEOUT_SECONDS = 30
+
 
 class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
     """WalkingPad coordinator."""
@@ -43,10 +46,20 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
             "session_running_time": 0,
             "session_distance": 0,
             "session_steps": 0,
+            "session_calories": 0,
             "status_timestamp": 0,
         }
+        # Deferred disconnect: when set, the coordinator will call
+        # async_set_stay_connected(False) once belt_state == STOPPED.
+        self._deferred_disconnect_pending: bool = False
+        self._deferred_disconnect_timeout_cancel: CALLBACK_TYPE | None = None
 
     async def _async_update_data(self) -> WalkingPadStatus:
+        # When stay_connected is disabled, skip polling/auto-reconnect entirely.
+        # Sensors will show stale data; commands handle their own connect/disconnect.
+        if not self.walkingpad_device.stay_connected:
+            return self.data
+
         async with asyncio.timeout(STATUS_UPDATE_TIMEOUT_SECONDS):
             await self.walkingpad_device.update_state()
             # We don't know the status yet, it will be transmitted to the _async_handle_update callback.
@@ -64,6 +77,19 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
         if status.get("status_timestamp", 0) > self.data.get("status_timestamp", 0):
             _LOGGER.debug("WalkingPad status update : %s", status)
             self.async_set_updated_data(status)
+
+            # Check deferred disconnect: once belt is fully stopped, disconnect.
+            if (
+                self._deferred_disconnect_pending
+                and status.get("belt_state") == BeltState.STOPPED
+            ):
+                _LOGGER.info("Belt stopped, executing deferred disconnect")
+                self._deferred_disconnect_pending = False
+                self._cancel_deferred_disconnect_timeout()
+                self.hass.async_create_task(
+                    self.async_set_stay_connected(False),
+                    "Deferred disconnect after belt stop",
+                )
 
     @callback
     def _async_handle_disconnect(self) -> None:
@@ -83,7 +109,7 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
         self, update_callback: CALLBACK_TYPE, context: Any = None
     ) -> Callable[[], None]:
         """Connect the device and listen for data updates."""
-        if not self._listeners:
+        if not self._listeners and self.walkingpad_device.stay_connected:
             async_call_later(
                 self.hass,
                 0,
@@ -100,3 +126,78 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
             HassJob(self._async_disconnect, "Disonnect the WalkingPad"),
         )
         return super()._unschedule_refresh()
+
+    async def async_set_stay_connected(self, value: bool) -> None:
+        """Handle the stay_connected toggle from the switch entity.
+
+        When turned ON: set the property and trigger an immediate connect + poll.
+        When turned OFF: set the property and disconnect immediately.
+        """
+        self.walkingpad_device.stay_connected = value
+        if value:
+            # User explicitly enabled stay_connected — cancel any pending
+            # deferred disconnect so we don't disconnect out from under them.
+            self._cancel_deferred_disconnect()
+            # Reconnect and resume polling
+            await self._async_connect()
+        else:
+            # Disconnect immediately to free BLE link for phone app
+            await self._async_disconnect()
+
+    def async_schedule_deferred_disconnect(self) -> None:
+        """Schedule a disconnect that fires once the belt reaches STOPPED.
+
+        Called by belt switch async_turn_off instead of an immediate
+        async_set_stay_connected(False).  The coordinator keeps polling
+        (stay_connected stays True) so the UI shows live deceleration data.
+        Once _async_handle_update sees belt_state == STOPPED, it calls
+        async_set_stay_connected(False).
+
+        A timeout ensures we disconnect even if STOPPED is never observed
+        (e.g. BLE drops during deceleration).
+        """
+        # If there's already a pending deferred disconnect, don't double-schedule.
+        if self._deferred_disconnect_pending:
+            _LOGGER.debug("Deferred disconnect already pending, ignoring")
+            return
+
+        _LOGGER.info(
+            "Scheduling deferred disconnect (timeout=%ss)",
+            DEFERRED_DISCONNECT_TIMEOUT_SECONDS,
+        )
+        self._deferred_disconnect_pending = True
+
+        # Safety timeout — disconnect anyway if we never see STOPPED.
+        self._deferred_disconnect_timeout_cancel = async_call_later(
+            self.hass,
+            DEFERRED_DISCONNECT_TIMEOUT_SECONDS,
+            HassJob(
+                self._async_deferred_disconnect_timeout,
+                "Deferred disconnect timeout",
+            ),
+        )
+
+    async def _async_deferred_disconnect_timeout(self, *_) -> None:
+        """Handle timeout when belt never reached STOPPED state."""
+        if not self._deferred_disconnect_pending:
+            return
+        _LOGGER.warning(
+            "Deferred disconnect timed out after %ss — disconnecting anyway",
+            DEFERRED_DISCONNECT_TIMEOUT_SECONDS,
+        )
+        self._deferred_disconnect_pending = False
+        self._deferred_disconnect_timeout_cancel = None
+        await self.async_set_stay_connected(False)
+
+    def _cancel_deferred_disconnect(self) -> None:
+        """Cancel any pending deferred disconnect (flag + timeout)."""
+        if self._deferred_disconnect_pending:
+            _LOGGER.debug("Cancelling pending deferred disconnect")
+        self._deferred_disconnect_pending = False
+        self._cancel_deferred_disconnect_timeout()
+
+    def _cancel_deferred_disconnect_timeout(self) -> None:
+        """Cancel the deferred disconnect timeout timer if running."""
+        if self._deferred_disconnect_timeout_cancel is not None:
+            self._deferred_disconnect_timeout_cancel()
+            self._deferred_disconnect_timeout_cancel = None

--- a/custom_components/king_smith/coordinator.py
+++ b/custom_components/king_smith/coordinator.py
@@ -73,8 +73,28 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
 
     @callback
     def _async_handle_disconnect(self) -> None:
-        """Trigger the callbacks for disconnected."""
+        """Trigger the callbacks for disconnected, and schedule reconnect
+        attempts when stay_connected is on.
+
+        KingSmith firmware sometimes drops the BLE link mid-command (e.g.
+        during START_OR_RESUME) AND then refuses new connections for tens
+        of seconds. A single reconnect attempt won't recover; we instead
+        schedule a series of attempts with backoff. The library bails
+        early on subsequent calls when CONNECTING/CONNECTED so this is
+        cheap when the first attempt does succeed.
+        """
         self.async_update_listeners()
+        if not self.walkingpad_device.stay_connected:
+            return
+        for delay in (3, 10, 30, 60):
+            async_call_later(
+                self.hass,
+                delay,
+                HassJob(
+                    self._async_connect,
+                    f"Reconnect after BLE drop (+{delay}s)",
+                ),
+            )
 
     async def _async_connect(self, *_) -> None:
         """Connect to the device."""
@@ -99,12 +119,19 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
 
     @callback
     def _unschedule_refresh(self) -> None:
-        """Unschedule any pending refresh since there is no longer any listeners."""
-        async_call_later(
-            self.hass,
-            0,
-            HassJob(self._async_disconnect, "Disonnect the WalkingPad"),
-        )
+        """Stop polling when no listeners remain.
+
+        Only disconnect the BLE link if Stay-connected is OFF — when it's
+        ON the user has explicitly opted in to a persistent connection
+        and we should keep it alive even while they're on a different
+        HA page (so coming back doesn't show a disconnected device).
+        """
+        if not self.walkingpad_device.stay_connected:
+            async_call_later(
+                self.hass,
+                0,
+                HassJob(self._async_disconnect, "Disconnect the WalkingPad"),
+            )
         return super()._unschedule_refresh()
 
     async def async_set_stay_connected(self, value: bool) -> None:

--- a/custom_components/king_smith/coordinator.py
+++ b/custom_components/king_smith/coordinator.py
@@ -35,6 +35,7 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
         )
         self.walkingpad_device = walkingpad_device
         self.walkingpad_device.register_status_callback(self._async_handle_update)
+        self.walkingpad_device.register_disconnect_callback(self._async_handle_disconnect)
         self.data = {
             "belt_state": BeltState.STOPPED,
             "speed": 0.0,

--- a/custom_components/king_smith/coordinator.py
+++ b/custom_components/king_smith/coordinator.py
@@ -20,10 +20,6 @@ STATUS_UPDATE_INTERVAL = timedelta(seconds=5)
 # The ph4_walkingpad has a 10s timeout in its connect method, you might have trouble if you set a smaller timeout here.
 STATUS_UPDATE_TIMEOUT_SECONDS = 11
 
-# How long to wait for the belt to fully stop before giving up and disconnecting.
-DEFERRED_DISCONNECT_TIMEOUT_SECONDS = 30
-
-
 class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
     """WalkingPad coordinator."""
 
@@ -49,10 +45,6 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
             "session_calories": 0,
             "status_timestamp": 0,
         }
-        # Deferred disconnect: when set, the coordinator will call
-        # async_set_stay_connected(False) once belt_state == STOPPED.
-        self._deferred_disconnect_pending: bool = False
-        self._deferred_disconnect_timeout_cancel: CALLBACK_TYPE | None = None
 
     async def _async_update_data(self) -> WalkingPadStatus:
         # When stay_connected is disabled, skip polling/auto-reconnect entirely.
@@ -77,19 +69,6 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
         if status.get("status_timestamp", 0) > self.data.get("status_timestamp", 0):
             _LOGGER.debug("WalkingPad status update : %s", status)
             self.async_set_updated_data(status)
-
-            # Check deferred disconnect: once belt is fully stopped, disconnect.
-            if (
-                self._deferred_disconnect_pending
-                and status.get("belt_state") == BeltState.STOPPED
-            ):
-                _LOGGER.info("Belt stopped, executing deferred disconnect")
-                self._deferred_disconnect_pending = False
-                self._cancel_deferred_disconnect_timeout()
-                self.hass.async_create_task(
-                    self.async_set_stay_connected(False),
-                    "Deferred disconnect after belt stop",
-                )
 
     @callback
     def _async_handle_disconnect(self) -> None:
@@ -135,69 +114,8 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
         """
         self.walkingpad_device.stay_connected = value
         if value:
-            # User explicitly enabled stay_connected — cancel any pending
-            # deferred disconnect so we don't disconnect out from under them.
-            self._cancel_deferred_disconnect()
             # Reconnect and resume polling
             await self._async_connect()
         else:
             # Disconnect immediately to free BLE link for phone app
             await self._async_disconnect()
-
-    def async_schedule_deferred_disconnect(self) -> None:
-        """Schedule a disconnect that fires once the belt reaches STOPPED.
-
-        Called by belt switch async_turn_off instead of an immediate
-        async_set_stay_connected(False).  The coordinator keeps polling
-        (stay_connected stays True) so the UI shows live deceleration data.
-        Once _async_handle_update sees belt_state == STOPPED, it calls
-        async_set_stay_connected(False).
-
-        A timeout ensures we disconnect even if STOPPED is never observed
-        (e.g. BLE drops during deceleration).
-        """
-        # If there's already a pending deferred disconnect, don't double-schedule.
-        if self._deferred_disconnect_pending:
-            _LOGGER.debug("Deferred disconnect already pending, ignoring")
-            return
-
-        _LOGGER.info(
-            "Scheduling deferred disconnect (timeout=%ss)",
-            DEFERRED_DISCONNECT_TIMEOUT_SECONDS,
-        )
-        self._deferred_disconnect_pending = True
-
-        # Safety timeout — disconnect anyway if we never see STOPPED.
-        self._deferred_disconnect_timeout_cancel = async_call_later(
-            self.hass,
-            DEFERRED_DISCONNECT_TIMEOUT_SECONDS,
-            HassJob(
-                self._async_deferred_disconnect_timeout,
-                "Deferred disconnect timeout",
-            ),
-        )
-
-    async def _async_deferred_disconnect_timeout(self, *_) -> None:
-        """Handle timeout when belt never reached STOPPED state."""
-        if not self._deferred_disconnect_pending:
-            return
-        _LOGGER.warning(
-            "Deferred disconnect timed out after %ss — disconnecting anyway",
-            DEFERRED_DISCONNECT_TIMEOUT_SECONDS,
-        )
-        self._deferred_disconnect_pending = False
-        self._deferred_disconnect_timeout_cancel = None
-        await self.async_set_stay_connected(False)
-
-    def _cancel_deferred_disconnect(self) -> None:
-        """Cancel any pending deferred disconnect (flag + timeout)."""
-        if self._deferred_disconnect_pending:
-            _LOGGER.debug("Cancelling pending deferred disconnect")
-        self._deferred_disconnect_pending = False
-        self._cancel_deferred_disconnect_timeout()
-
-    def _cancel_deferred_disconnect_timeout(self) -> None:
-        """Cancel the deferred disconnect timeout timer if running."""
-        if self._deferred_disconnect_timeout_cancel is not None:
-            self._deferred_disconnect_timeout_cancel()
-            self._deferred_disconnect_timeout_cancel = None

--- a/custom_components/king_smith/coordinator.py
+++ b/custom_components/king_smith/coordinator.py
@@ -1,12 +1,14 @@
 """The Walking Pad Coordinator."""
 
 import asyncio
+import itertools
 import logging
 from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 
 from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -17,8 +19,11 @@ _LOGGER = logging.getLogger(__name__)
 
 STATUS_UPDATE_INTERVAL = timedelta(seconds=5)
 
-# The ph4_walkingpad has a 10s timeout in its connect method, you might have trouble if you set a smaller timeout here.
-STATUS_UPDATE_TIMEOUT_SECONDS = 11
+# Must accommodate the library's full connect-retry cycle (FTMS: up to 5 ×
+# 10 s + small gaps ≈ 55 s). Cancelling mid-cycle leaves Bleak in a flaky
+# state and used to leak the WalkingPad's CONNECTING status, jamming all
+# subsequent reconnects until something kicked it loose.
+STATUS_UPDATE_TIMEOUT_SECONDS = 60
 
 class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
     """WalkingPad coordinator."""
@@ -36,6 +41,14 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
         self.walkingpad_device = walkingpad_device
         self.walkingpad_device.register_status_callback(self._async_handle_update)
         self.walkingpad_device.register_disconnect_callback(self._async_handle_disconnect)
+        # Single reconnect task — coordinated by _async_handle_disconnect so we
+        # don't spawn parallel reconnect attempts that race each other.
+        self._reconnect_task: asyncio.Task[None] | None = None
+        # firmware_version is empty at entity construction time (the library
+        # only reads it on connect), so the DeviceInfo snapshots in entity
+        # __init__ all see ""/None. We push the real value into the device
+        # registry once it's known — see _async_push_firmware_once.
+        self._firmware_pushed: bool = False
         self.data = {
             "belt_state": BeltState.STOPPED,
             "speed": 0.0,
@@ -70,31 +83,77 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
         if status.get("status_timestamp", 0) > self.data.get("status_timestamp", 0):
             _LOGGER.debug("WalkingPad status update : %s", status)
             self.async_set_updated_data(status)
+        self._async_push_firmware_once()
+
+    @callback
+    def _async_push_firmware_once(self) -> None:
+        """Update the device registry's sw_version once firmware is known.
+
+        Entities snapshot ``firmware_version`` into their DeviceInfo at
+        __init__ time, but the library doesn't read it until connect, so
+        the device card otherwise stays blank. We push it here on the
+        first status update where the library has it available.
+        """
+        if self._firmware_pushed:
+            return
+        fw = self.walkingpad_device.firmware_version
+        if not fw:
+            return
+        device_registry = dr.async_get(self.hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, self.walkingpad_device.mac)}
+        )
+        if device is None:
+            return
+        if device.sw_version != fw:
+            device_registry.async_update_device(device.id, sw_version=fw)
+        self._firmware_pushed = True
 
     @callback
     def _async_handle_disconnect(self) -> None:
-        """Trigger the callbacks for disconnected, and schedule reconnect
-        attempts when stay_connected is on.
-
-        KingSmith firmware sometimes drops the BLE link mid-command (e.g.
-        during START_OR_RESUME) AND then refuses new connections for tens
-        of seconds. A single reconnect attempt won't recover; we instead
-        schedule a series of attempts with backoff. The library bails
-        early on subsequent calls when CONNECTING/CONNECTED so this is
-        cheap when the first attempt does succeed.
-        """
+        """Update listeners and (re)start the reconnect loop if stay_connected."""
         self.async_update_listeners()
+        self._ensure_reconnect_running()
+
+    async def _reconnect_loop(self) -> None:
+        """Reconnect with backoff, bailing as soon as the link is back.
+
+        First iteration tries immediately (delay 0) — when the BLE link
+        drops, the treadmill is often re-advertising within a hundred ms,
+        so any wait here is pure latency. Backoff ramps up only if the
+        device stays unreachable, capping at 30 s sustained — we never
+        want to give up while stay_connected is on, since the treadmill
+        might just be powered off and the user could turn it on at any
+        moment.
+        """
+        for delay in itertools.chain((0, 2, 5, 10, 15), itertools.repeat(30)):
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+            if not self.walkingpad_device.stay_connected:
+                return
+            if self.walkingpad_device.connected:
+                return
+            _LOGGER.info("Reconnect attempt after %ss", delay)
+            try:
+                await self.walkingpad_device.connect()
+            except Exception:
+                _LOGGER.exception("Reconnect attempt failed")
+            if self.walkingpad_device.connected:
+                return
+
+    @callback
+    def _ensure_reconnect_running(self) -> None:
+        """Spawn the reconnect loop if not already in flight."""
         if not self.walkingpad_device.stay_connected:
             return
-        for delay in (3, 10, 30, 60):
-            async_call_later(
-                self.hass,
-                delay,
-                HassJob(
-                    self._async_connect,
-                    f"Reconnect after BLE drop (+{delay}s)",
-                ),
-            )
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            return
+        self._reconnect_task = self.hass.async_create_task(
+            self._reconnect_loop(),
+            name="walkingpad-reconnect",
+        )
 
     async def _async_connect(self, *_) -> None:
         """Connect to the device."""
@@ -108,13 +167,15 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
     def async_add_listener(
         self, update_callback: CALLBACK_TYPE, context: Any = None
     ) -> Callable[[], None]:
-        """Connect the device and listen for data updates."""
-        if not self._listeners and self.walkingpad_device.stay_connected:
-            async_call_later(
-                self.hass,
-                0,
-                HassJob(self._async_connect, "Connect to WalkingPad"),
-            )
+        """Listen for data updates; trigger reconnect loop on first listener."""
+        if (
+            not self._listeners
+            and self.walkingpad_device.stay_connected
+            and not self.walkingpad_device.connected
+        ):
+            # Use the same reconnect loop as mid-session drops, so failed initial
+            # connects retry with backoff instead of becoming a one-shot fail.
+            self._ensure_reconnect_running()
         return super().async_add_listener(update_callback, context)
 
     @callback
@@ -134,16 +195,44 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
             )
         return super()._unschedule_refresh()
 
+    async def async_shutdown(self) -> None:
+        """Cancel reconnect task and disconnect on integration unload.
+
+        Without this, a reload would leave the old coordinator's reconnect
+        task and BLE callbacks alive, so a new coordinator's events fire
+        twice (or more, after multiple reloads).
+        """
+        await self._cancel_reconnect_task()
+        await super().async_shutdown()
+        await self._async_disconnect()
+
     async def async_set_stay_connected(self, value: bool) -> None:
         """Handle the stay_connected toggle from the switch entity.
 
-        When turned ON: set the property and trigger an immediate connect + poll.
-        When turned OFF: set the property and disconnect immediately.
+        When turned ON: route through the reconnect loop so failed connects
+        retry with backoff instead of being a one-shot fail.
+        When turned OFF: cancel any in-flight reconnect and disconnect.
         """
         self.walkingpad_device.stay_connected = value
         if value:
-            # Reconnect and resume polling
-            await self._async_connect()
+            self._ensure_reconnect_running()
         else:
-            # Disconnect immediately to free BLE link for phone app
+            await self._cancel_reconnect_task()
             await self._async_disconnect()
+
+    async def _cancel_reconnect_task(self) -> None:
+        """Cancel the reconnect loop and wait for it to actually finish.
+
+        ``cancel()`` only marks the task; the cancellation propagates on
+        the next event-loop tick. Without awaiting we'd race the in-flight
+        ``walkingpad.connect()`` against the immediate ``disconnect()``
+        that follows, both touching ``_connection_status``.
+        """
+        task = self._reconnect_task
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass

--- a/custom_components/king_smith/coordinator.py
+++ b/custom_components/king_smith/coordinator.py
@@ -57,6 +57,8 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
             "session_distance": 0,
             "session_steps": 0,
             "session_calories": 0,
+            "vibration_level": 0,
+            "incline": 0,
             "status_timestamp": 0,
         }
 
@@ -65,6 +67,14 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
         # Sensors will show stale data; commands handle their own connect/disconnect.
         if not self.walkingpad_device.stay_connected:
             return self.data
+
+        # Safety net for silently-dropped links: the reconnect loop is normally
+        # started by the BLE disconnect callback, but if a link dies without
+        # that callback firing (seen on flaky BT proxies), nothing would re-arm
+        # it. This periodic poll notices we're down and (idempotently) ensures
+        # the reconnect loop is running.
+        if not self.walkingpad_device.connected:
+            self._ensure_reconnect_running()
 
         async with asyncio.timeout(STATUS_UPDATE_TIMEOUT_SECONDS):
             await self.walkingpad_device.update_state()
@@ -205,6 +215,26 @@ class WalkingPadCoordinator(DataUpdateCoordinator[WalkingPadStatus]):
         await self._cancel_reconnect_task()
         await super().async_shutdown()
         await self._async_disconnect()
+
+    async def async_reconnect_now(self) -> None:
+        """Force an immediate reconnect attempt (from the Reconnect button).
+
+        The reconnect loop already retries on its own, but after a few
+        failures it settles into a 30 s backoff sleep — so when the user
+        powers the treadmill back on, HA can take up to half a minute to
+        notice. This method short-circuits that wait: it cancels the
+        in-flight loop (which may be mid-sleep), connects right away, then
+        re-arms the loop if we're still down and stay_connected is on so a
+        failed press keeps retrying with backoff.
+
+        Works regardless of stay_connected — a manual press is an explicit
+        "connect now", the same affordance the KS Fit app exposes.
+        """
+        await self._cancel_reconnect_task()
+        await self.walkingpad_device.connect()
+        self.async_update_listeners()
+        if not self.walkingpad_device.connected:
+            self._ensure_reconnect_running()
 
     async def async_set_stay_connected(self, value: bool) -> None:
         """Handle the stay_connected toggle from the switch entity.

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -62,6 +62,6 @@
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.9",
+  "version": "0.4.10",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -62,6 +62,6 @@
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.4",
+  "version": "0.4.5",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -62,6 +62,6 @@
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.6",
+  "version": "0.4.7",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -62,6 +62,6 @@
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.8",
+  "version": "0.4.9",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -62,6 +62,6 @@
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.1",
+  "version": "0.4.2",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -58,10 +58,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.4",
+    "walkingpad-controller>=0.4.5",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.7",
+  "version": "0.4.8",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -58,10 +58,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.3",
+    "walkingpad-controller>=0.4.4",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.3",
+  "version": "0.4.4",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -58,10 +58,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.0",
+    "walkingpad-controller>=0.4.1",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.0",
+  "version": "0.4.1",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -62,6 +62,6 @@
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.5",
+  "version": "0.4.6",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -39,24 +39,29 @@
       "local_name": "KS-X21*"
     },
     {
+      "local_name": "KS-HD-*"
+    },
+    {
       "local_name": "WalkingPad"
     }
   ],
   "codeowners": [
-    "@madmatah"
+    "@madmatah",
+    "@mcdax"
   ],
   "config_flow": true,
   "dependencies": [
     "bluetooth_adapters"
   ],
-  "documentation": "https://github.com/madmatah/hass-walkingpad",
+  "documentation": "https://github.com/mcdax/hass-walkingpad",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/madmatah/hass-walkingpad/issues",
+  "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
+    "walkingpad-controller>=0.4.0",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.3.0",
+  "version": "0.4.0",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -58,10 +58,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.1",
+    "walkingpad-controller>=0.4.3",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.2",
+  "version": "0.4.3",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -58,10 +58,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.5",
+    "walkingpad-controller>=0.4.6",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.10",
+  "version": "0.4.11",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -58,10 +58,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.7",
+    "walkingpad-controller>=0.4.8",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.12",
+  "version": "0.4.13",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -58,10 +58,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.6",
+    "walkingpad-controller>=0.4.7",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.11",
+  "version": "0.4.12",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -62,6 +62,6 @@
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.14",
+  "version": "0.4.15",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -58,10 +58,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.10",
+    "walkingpad-controller>=0.4.11",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.15",
+  "version": "0.4.16",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -58,10 +58,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.8",
+    "walkingpad-controller>=0.4.10",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.13",
+  "version": "0.4.14",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -46,6 +46,9 @@
     },
     {
       "local_name": "SPERAX_RM-01_*"
+    },
+    {
+      "local_name": "SPERAX_P3MAX*"
     }
   ],
   "codeowners": [
@@ -61,10 +64,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.4.11",
+    "walkingpad-controller>=0.5.0",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.4.16",
+  "version": "0.5.0",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -64,10 +64,10 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mcdax/hass-walkingpad/issues",
   "requirements": [
-    "walkingpad-controller>=0.5.0",
+    "walkingpad-controller>=0.5.1",
     "ph4-walkingpad==1.0.2"
   ],
   "ssdp": [],
-  "version": "0.5.0",
+  "version": "0.5.1",
   "zeroconf": []
 }

--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -43,6 +43,9 @@
     },
     {
       "local_name": "WalkingPad"
+    },
+    {
+      "local_name": "SPERAX_RM-01_*"
     }
   ],
   "codeowners": [

--- a/custom_components/king_smith/number.py
+++ b/custom_components/king_smith/number.py
@@ -63,6 +63,7 @@ class WalkingPadSpeedNumberEntity(
         """Initialize the speed number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.walkingpad_device.mac}-{NUMBER_KEY}"
+        self._attr_suggested_object_id = NUMBER_KEY
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
             name=coordinator.walkingpad_device.name,
@@ -87,23 +88,35 @@ class WalkingPadSpeedNumberEntity(
         return self.coordinator.walkingpad_device.speed_increment
 
     @property
-    def native_value(self) -> float:
-        """Return the current speed."""
+    def native_value(self) -> float | None:
+        """Return the current speed, or None when disconnected.
+
+        Returning None marks the displayed value as unknown but keeps
+        the entity available so the user can still send a target speed
+        — see `available` below.
+        """
+        if not self.coordinator.connected:
+            return None
         return self.coordinator.data.get("speed", 0.0)
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the speed.
 
-        For FTMS devices, setting a target speed also starts the belt,
-        so we allow speed changes even when the belt is stopped.
-        For legacy devices, speed can only be changed when the belt is active.
+        For FTMS devices, setting a target speed also starts the belt
+        (the library handles the cold-start sequence), so we accept
+        speed changes whether or not the belt is currently running and
+        whether or not we are currently connected — the underlying
+        WalkingPad wrapper will connect-and-issue as needed.
+
+        For legacy WiLink devices, the firmware only accepts speed
+        changes while the belt is moving, so we keep the existing
+        belt-state guard for them.
         """
         from .const import ProtocolType
 
         device = self.coordinator.walkingpad_device
         belt_state = self.coordinator.data.get("belt_state")
 
-        # Legacy devices require the belt to be running before changing speed
         if device.protocol == ProtocolType.WILINK and belt_state not in [
             BeltState.ACTIVE,
             BeltState.STARTING,
@@ -114,5 +127,12 @@ class WalkingPadSpeedNumberEntity(
 
     @property
     def available(self) -> bool:
-        """Return if entity is available."""
-        return self.coordinator.connected
+        """The slider stays available even when the BLE link is down.
+
+        On FTMS devices `set_native_value` triggers a connect-and-set
+        sequence, so the user can drag the slider to start a walk
+        directly without first toggling Stay-connected on. On WiLink
+        devices the slider is hidden (entity removed) when remote
+        control isn't enabled, so this only ever matters for FTMS.
+        """
+        return True

--- a/custom_components/king_smith/number.py
+++ b/custom_components/king_smith/number.py
@@ -67,6 +67,8 @@ class WalkingPadSpeedNumberEntity(
             identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
             name=coordinator.walkingpad_device.name,
             manufacturer="KingSmith",
+            model=coordinator.walkingpad_device.name,
+            sw_version=coordinator.walkingpad_device.firmware_version or None,
         )
 
     @property

--- a/custom_components/king_smith/number.py
+++ b/custom_components/king_smith/number.py
@@ -5,6 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfSpeed
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -53,9 +54,6 @@ class WalkingPadSpeedNumberEntity(
 ):
     """Represent the WalkingPad speed number."""
 
-    _attr_native_min_value = 0.5
-    _attr_native_max_value = 6.0
-    _attr_native_step = 0.1
     _attr_mode = NumberMode.AUTO
     _attr_native_unit_of_measurement = UnitOfSpeed.KILOMETERS_PER_HOUR
     _attr_has_entity_name = True
@@ -65,6 +63,26 @@ class WalkingPadSpeedNumberEntity(
         """Initialize the speed number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.walkingpad_device.mac}-{NUMBER_KEY}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
+            name=coordinator.walkingpad_device.name,
+            manufacturer="KingSmith",
+        )
+
+    @property
+    def native_min_value(self) -> float:
+        """Return min speed from device capabilities (updates after connection)."""
+        return self.coordinator.walkingpad_device.min_speed
+
+    @property
+    def native_max_value(self) -> float:
+        """Return max speed from device capabilities (updates after connection)."""
+        return self.coordinator.walkingpad_device.max_speed
+
+    @property
+    def native_step(self) -> float:
+        """Return speed increment from device capabilities (updates after connection)."""
+        return self.coordinator.walkingpad_device.speed_increment
 
     @property
     def native_value(self) -> float:
@@ -72,11 +90,25 @@ class WalkingPadSpeedNumberEntity(
         return self.coordinator.data.get("speed", 0.0)
 
     async def async_set_native_value(self, value: float) -> None:
-        """Set the speed."""
+        """Set the speed.
+
+        For FTMS devices, setting a target speed also starts the belt,
+        so we allow speed changes even when the belt is stopped.
+        For legacy devices, speed can only be changed when the belt is active.
+        """
+        from .const import ProtocolType
+
+        device = self.coordinator.walkingpad_device
         belt_state = self.coordinator.data.get("belt_state")
-        if belt_state not in [BeltState.ACTIVE, BeltState.STARTING]:
+
+        # Legacy devices require the belt to be running before changing speed
+        if device.protocol == ProtocolType.WILINK and belt_state not in [
+            BeltState.ACTIVE,
+            BeltState.STARTING,
+        ]:
             return
-        await self.coordinator.walkingpad_device.set_speed(value)
+
+        await device.set_speed(value)
 
     @property
     def available(self) -> bool:

--- a/custom_components/king_smith/number.py
+++ b/custom_components/king_smith/number.py
@@ -1,6 +1,10 @@
 """Walkingpad number support."""
 
-from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberMode,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfSpeed
 from homeassistant.core import HomeAssistant
@@ -17,11 +21,14 @@ from .const import (
     DEFAULT_PREFERRED_MODE,
     DOMAIN,
     BeltState,
+    ProtocolType,
     WalkingPadMode,
 )
 from .coordinator import WalkingPadCoordinator
 
 NUMBER_KEY = "walkingpad_speed"
+VIBRATION_KEY = "walkingpad_vibration"
+INCLINE_KEY = "walkingpad_incline"
 
 
 async def async_setup_entry(
@@ -36,17 +43,23 @@ async def async_setup_entry(
     if not (remote_control_enabled and preferred_mode == manual_mode):
         entity_registry = er.async_get(hass)
         mac_address = entry.data.get(CONF_MAC)
-        unique_id = f"{mac_address}-{NUMBER_KEY}"
-
-        entity_id = entity_registry.async_get_entity_id("number", DOMAIN, unique_id)
-        if entity_id:
-            entity_registry.async_remove(entity_id)
+        for key in (NUMBER_KEY, VIBRATION_KEY, INCLINE_KEY):
+            unique_id = f"{mac_address}-{key}"
+            entity_id = entity_registry.async_get_entity_id("number", DOMAIN, unique_id)
+            if entity_id:
+                entity_registry.async_remove(entity_id)
         return
 
     entry_data: WalkingPadIntegrationData = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
 
-    async_add_entities([WalkingPadSpeedNumberEntity(coordinator)])
+    entities: list[NumberEntity] = [WalkingPadSpeedNumberEntity(coordinator)]
+    # Incline and vibration are Sperax P3 Max (WLT6200) features only.
+    if coordinator.walkingpad_device.protocol == ProtocolType.SPERAX:
+        entities.append(WalkingPadInclineNumberEntity(coordinator))
+        entities.append(WalkingPadVibrationNumberEntity(coordinator))
+
+    async_add_entities(entities)
 
 
 class WalkingPadSpeedNumberEntity(
@@ -55,6 +68,13 @@ class WalkingPadSpeedNumberEntity(
     """Represent the WalkingPad speed number."""
 
     _attr_mode = NumberMode.AUTO
+    # Native unit is km/h (what the belt speaks). The SPEED device class lets
+    # HA convert the displayed min/max/step/value to the user's preferred unit
+    # (e.g. mph on a US unit system, or a per-entity override) and convert the
+    # value they set back to km/h before it reaches the device — matching how
+    # the "Current speed" sensor already behaves. Note the conversion applies
+    # to the whole scale, so the 0.5 km/h step lands on non-round mph values.
+    _attr_device_class = NumberDeviceClass.SPEED
     _attr_native_unit_of_measurement = UnitOfSpeed.KILOMETERS_PER_HOUR
     _attr_has_entity_name = True
     _attr_translation_key = "walkingpad_speed"
@@ -136,3 +156,87 @@ class WalkingPadSpeedNumberEntity(
         control isn't enabled, so this only ever matters for FTMS.
         """
         return True
+
+
+class WalkingPadVibrationNumberEntity(
+    CoordinatorEntity[WalkingPadCoordinator], NumberEntity
+):
+    """Vibration level control for Sperax P3 Max (WLT6200) devices.
+
+    Level 0 turns vibration off; 1-4 select the intensity. On the P3 Max the
+    belt and the vibration motor are mutually exclusive — selecting a level
+    stops the belt.
+    """
+
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_min_value = 0
+    _attr_native_max_value = 4
+    _attr_native_step = 1
+    _attr_has_entity_name = True
+    _attr_translation_key = VIBRATION_KEY
+
+    def __init__(self, coordinator: WalkingPadCoordinator) -> None:
+        """Initialize the vibration number."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.walkingpad_device.mac}-{VIBRATION_KEY}"
+        self._attr_suggested_object_id = VIBRATION_KEY
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
+            name=coordinator.walkingpad_device.name,
+            manufacturer="Sperax",
+            model=coordinator.walkingpad_device.name,
+            sw_version=coordinator.walkingpad_device.firmware_version or None,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current vibration level, or None when disconnected."""
+        if not self.coordinator.connected:
+            return None
+        return self.coordinator.data.get("vibration_level", 0)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the vibration level (0 = off, 1-4)."""
+        await self.coordinator.walkingpad_device.set_vibration(int(value))
+
+
+class WalkingPadInclineNumberEntity(
+    CoordinatorEntity[WalkingPadCoordinator], NumberEntity
+):
+    """Incline level control for Sperax P3 Max (WLT6200) devices.
+
+    Range 0 (flat) to 10 (max). The device has no decline. Incline rides
+    inside the run command, so the library only applies it while the belt is
+    moving and otherwise caches it for the next start.
+    """
+
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_min_value = 0
+    _attr_native_max_value = 10
+    _attr_native_step = 1
+    _attr_has_entity_name = True
+    _attr_translation_key = INCLINE_KEY
+
+    def __init__(self, coordinator: WalkingPadCoordinator) -> None:
+        """Initialize the incline number."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.walkingpad_device.mac}-{INCLINE_KEY}"
+        self._attr_suggested_object_id = INCLINE_KEY
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
+            name=coordinator.walkingpad_device.name,
+            manufacturer="Sperax",
+            model=coordinator.walkingpad_device.name,
+            sw_version=coordinator.walkingpad_device.firmware_version or None,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current incline level, or None when disconnected."""
+        if not self.coordinator.connected:
+            return None
+        return self.coordinator.data.get("incline", 0)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the incline level (0-10)."""
+        await self.coordinator.walkingpad_device.set_incline(int(value))

--- a/custom_components/king_smith/sensor.py
+++ b/custom_components/king_smith/sensor.py
@@ -280,6 +280,11 @@ class WalkingPadSensor(
         self._attr_unique_id = (
             f"{coordinator.walkingpad_device.mac}-{self.entity_description.key}"
         )
+        # Pin the entity_id to a stable English slug derived from the
+        # description key, so HA doesn't auto-generate it from the
+        # localized friendly_name (which led to inconsistent IDs like
+        # `sensor.walkingpad_kalorienrate` in the past).
+        self._attr_suggested_object_id = self.entity_description.key
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
             name=coordinator.walkingpad_device.name,

--- a/custom_components/king_smith/sensor.py
+++ b/custom_components/king_smith/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfLength, UnitOfSpeed, UnitOfTime
+from homeassistant.const import EntityCategory, UnitOfLength, UnitOfSpeed, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -20,7 +20,15 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import WalkingPadIntegrationData
-from .const import DOMAIN, BeltState, ProtocolType, WalkingPadMode, WalkingPadStatus
+from .const import (
+    DOMAIN,
+    FTMS_FM_EVENT_NAMES,
+    FTMS_TRAINING_STATUS_NAMES,
+    BeltState,
+    ProtocolType,
+    WalkingPadMode,
+    WalkingPadStatus,
+)
 from .coordinator import WalkingPadCoordinator
 
 
@@ -98,7 +106,7 @@ COMMON_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
     ),
 )
 
-# Sensors only available for FTMS devices (calories reported via FTMS Expended Energy).
+# Sensors only available for FTMS devices.
 FTMS_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
     WalkingPadSensorEntityDescription(
         icon="mdi:fire",
@@ -109,6 +117,30 @@ FTMS_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         suggested_display_precision=0,
         translation_key="walkingpad_calories",
         value_fn=lambda status: status.get("session_calories", 0),
+    ),
+    WalkingPadSensorEntityDescription(
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:run",
+        key="walkingpad_training_status",
+        name=None,
+        options=list(FTMS_TRAINING_STATUS_NAMES.values()),
+        translation_key="walkingpad_training_status",
+        value_fn=lambda status: FTMS_TRAINING_STATUS_NAMES.get(
+            status.get("training_status", 0), "other"
+        ),
+    ),
+    WalkingPadSensorEntityDescription(
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:bell-ring",
+        key="walkingpad_last_event",
+        name=None,
+        options=list(FTMS_FM_EVENT_NAMES.values()),
+        translation_key="walkingpad_last_event",
+        value_fn=lambda status: FTMS_FM_EVENT_NAMES.get(
+            status.get("last_fm_event", 0), "none"
+        ),
     ),
 )
 

--- a/custom_components/king_smith/sensor.py
+++ b/custom_components/king_smith/sensor.py
@@ -14,12 +14,13 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfLength, UnitOfSpeed, UnitOfTime
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import WalkingPadIntegrationData
-from .const import DOMAIN, BeltState, WalkingPadMode, WalkingPadStatus
+from .const import DOMAIN, BeltState, ProtocolType, WalkingPadMode, WalkingPadStatus
 from .coordinator import WalkingPadCoordinator
 
 
@@ -30,7 +31,8 @@ class WalkingPadSensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[WalkingPadStatus], StateType]
 
 
-SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
+# Sensors available for all protocol types.
+COMMON_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
     WalkingPadSensorEntityDescription(
         device_class=SensorDeviceClass.DISTANCE,
         icon="mdi:walk",
@@ -43,44 +45,15 @@ SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         value_fn=lambda status: status.get("session_distance", 0.0) / 1000,
     ),
     WalkingPadSensorEntityDescription(
-        icon="mdi:shoe-print",
-        key="walkingpad_steps",
+        device_class=SensorDeviceClass.DURATION,
+        icon="mdi:timer",
+        key="walkingpad_duration",
         name=None,
-        native_unit_of_measurement="steps",
+        native_unit_of_measurement=UnitOfTime.SECONDS,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
-        translation_key="walkingpad_steps",
-        value_fn=lambda status: status.get("session_steps", 0),
-    ),
-    WalkingPadSensorEntityDescription(
-        icon="mdi:timer",
-        key="walkingpad_duration_minutes",
-        name=None,
-        native_unit_of_measurement=UnitOfTime.MINUTES,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        suggested_display_precision=0,
-        translation_key="walkingpad_duration_minutes",
-        value_fn=lambda status: round(status.get("session_running_time", 0) / 60, 1),
-    ),
-    WalkingPadSensorEntityDescription(
-        icon="mdi:timer",
-        key="walkingpad_duration_hours",
-        name=None,
-        native_unit_of_measurement=UnitOfTime.HOURS,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        suggested_display_precision=1,
-        translation_key="walkingpad_duration_hours",
-        value_fn=lambda status: round(status.get("session_running_time", 0) / 3600, 4),
-    ),
-    WalkingPadSensorEntityDescription(
-        icon="mdi:timer",
-        key="walkingpad_duration_days",
-        name=None,
-        native_unit_of_measurement=UnitOfTime.DAYS,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        suggested_display_precision=1,
-        translation_key="walkingpad_duration_days",
-        value_fn=lambda status: round(status.get("session_running_time", 0) / 86400, 6),
+        translation_key="walkingpad_duration",
+        value_fn=lambda status: status.get("session_running_time", 0),
     ),
     WalkingPadSensorEntityDescription(
         device_class=SensorDeviceClass.SPEED,
@@ -113,6 +86,30 @@ SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         translation_key="walkingpad_mode",
         value_fn=lambda status: status.get("mode", WalkingPadMode.MANUAL).name.lower(),
     ),
+    WalkingPadSensorEntityDescription(
+        icon="mdi:shoe-print",
+        key="walkingpad_steps",
+        name=None,
+        native_unit_of_measurement="steps",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
+        translation_key="walkingpad_steps",
+        value_fn=lambda status: status.get("session_steps", 0),
+    ),
+)
+
+# Sensors only available for FTMS devices (calories reported via FTMS Expended Energy).
+FTMS_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
+    WalkingPadSensorEntityDescription(
+        icon="mdi:fire",
+        key="walkingpad_calories",
+        name=None,
+        native_unit_of_measurement="kcal",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
+        translation_key="walkingpad_calories",
+        value_fn=lambda status: status.get("session_calories", 0),
+    ),
 )
 
 
@@ -123,9 +120,17 @@ async def async_setup_entry(
 
     entry_data: WalkingPadIntegrationData = hass.data[DOMAIN][entry.entry_id]
     coordinator = entry_data["coordinator"]
+    device = entry_data["device"]
+
+    # Build sensor list based on protocol type.
+    # Steps are in COMMON_SENSORS (available for both WiLink and FTMS).
+    sensors: list[WalkingPadSensorEntityDescription] = list(COMMON_SENSORS)
+
+    if device.protocol == ProtocolType.FTMS:
+        sensors.extend(FTMS_SENSORS)
 
     async_add_entities(
-        WalkingPadSensor(coordinator, description) for description in SENSORS
+        WalkingPadSensor(coordinator, description) for description in sensors
     )
 
 
@@ -150,6 +155,11 @@ class WalkingPadSensor(
         self.entity_description = entity_description
         self._attr_unique_id = (
             f"{coordinator.walkingpad_device.mac}-{self.entity_description.key}"
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
+            name=coordinator.walkingpad_device.name,
+            manufacturer="KingSmith",
         )
 
     @property

--- a/custom_components/king_smith/sensor.py
+++ b/custom_components/king_smith/sensor.py
@@ -34,9 +34,19 @@ from .coordinator import WalkingPadCoordinator
 
 @dataclass(kw_only=True)
 class WalkingPadSensorEntityDescription(SensorEntityDescription):
-    """Describes Example sensor entity."""
+    """Describes a WalkingPad sensor entity.
 
-    value_fn: Callable[[WalkingPadStatus], StateType]
+    `value_fn` receives the coordinator so it can read either dynamic
+    status (from `coord.data`) or static device-info (from
+    `coord.walkingpad_device`).
+
+    `static` flags sensors whose value comes from device capabilities
+    rather than runtime status — these stay available even while the
+    BLE link is down, since their value doesn't depend on live data.
+    """
+
+    value_fn: Callable[[WalkingPadCoordinator], StateType]
+    static: bool = False
 
 
 # Sensors available for all protocol types.
@@ -50,7 +60,7 @@ COMMON_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         translation_key="walkingpad_distance",
-        value_fn=lambda status: status.get("session_distance", 0.0) / 1000,
+        value_fn=lambda coord: coord.data.get("session_distance", 0.0) / 1000,
     ),
     WalkingPadSensorEntityDescription(
         device_class=SensorDeviceClass.DURATION,
@@ -61,7 +71,7 @@ COMMON_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
         translation_key="walkingpad_duration",
-        value_fn=lambda status: status.get("session_running_time", 0),
+        value_fn=lambda coord: coord.data.get("session_running_time", 0),
     ),
     WalkingPadSensorEntityDescription(
         device_class=SensorDeviceClass.SPEED,
@@ -72,7 +82,7 @@ COMMON_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         translation_key="walkingpad_current_speed",
-        value_fn=lambda status: status.get("speed", 0.0),
+        value_fn=lambda coord: coord.data.get("speed", 0.0),
     ),
     WalkingPadSensorEntityDescription(
         device_class=SensorDeviceClass.ENUM,
@@ -81,7 +91,7 @@ COMMON_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         name=None,
         options=[e.name.lower() for e in BeltState],
         translation_key="walkingpad_state",
-        value_fn=lambda status: status.get(
+        value_fn=lambda coord: coord.data.get(
             "belt_state", BeltState.UNKNOWN
         ).name.lower(),
     ),
@@ -92,7 +102,7 @@ COMMON_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         name=None,
         options=[e.name.lower() for e in WalkingPadMode],
         translation_key="walkingpad_mode",
-        value_fn=lambda status: status.get("mode", WalkingPadMode.MANUAL).name.lower(),
+        value_fn=lambda coord: coord.data.get("mode", WalkingPadMode.MANUAL).name.lower(),
     ),
     WalkingPadSensorEntityDescription(
         icon="mdi:shoe-print",
@@ -102,7 +112,56 @@ COMMON_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
         translation_key="walkingpad_steps",
-        value_fn=lambda status: status.get("session_steps", 0),
+        value_fn=lambda coord: coord.data.get("session_steps", 0),
+    ),
+    # --- Static device-info sensors below.  `static=True` keeps them
+    # available even while the BLE link is down. ---
+    WalkingPadSensorEntityDescription(
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:bluetooth",
+        key="walkingpad_protocol",
+        name=None,
+        options=["ftms", "wilink", "unknown"],
+        static=True,
+        translation_key="walkingpad_protocol",
+        value_fn=lambda coord: coord.walkingpad_device.protocol.value,
+    ),
+    WalkingPadSensorEntityDescription(
+        device_class=SensorDeviceClass.SPEED,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:speedometer-slow",
+        key="walkingpad_min_speed",
+        name=None,
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        static=True,
+        suggested_display_precision=1,
+        translation_key="walkingpad_min_speed",
+        value_fn=lambda coord: coord.walkingpad_device.min_speed,
+    ),
+    WalkingPadSensorEntityDescription(
+        device_class=SensorDeviceClass.SPEED,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:speedometer",
+        key="walkingpad_max_speed",
+        name=None,
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        static=True,
+        suggested_display_precision=1,
+        translation_key="walkingpad_max_speed",
+        value_fn=lambda coord: coord.walkingpad_device.max_speed,
+    ),
+    WalkingPadSensorEntityDescription(
+        device_class=SensorDeviceClass.SPEED,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:plus-minus-variant",
+        key="walkingpad_speed_increment",
+        name=None,
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        static=True,
+        suggested_display_precision=2,
+        translation_key="walkingpad_speed_increment",
+        value_fn=lambda coord: coord.walkingpad_device.speed_increment,
     ),
 )
 
@@ -116,7 +175,29 @@ FTMS_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
         translation_key="walkingpad_calories",
-        value_fn=lambda status: status.get("session_calories", 0),
+        value_fn=lambda coord: coord.data.get("session_calories", 0),
+    ),
+    WalkingPadSensorEntityDescription(
+        icon="mdi:fire-circle",
+        key="walkingpad_calories_per_hour",
+        name=None,
+        native_unit_of_measurement="kcal/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        translation_key="walkingpad_calories_per_hour",
+        value_fn=lambda coord: coord.data.get("session_calories_per_hour", 0),
+    ),
+    WalkingPadSensorEntityDescription(
+        icon="mdi:heart-pulse",
+        key="walkingpad_heart_rate",
+        name=None,
+        native_unit_of_measurement="bpm",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        translation_key="walkingpad_heart_rate",
+        # Treadmill reports 0 when no HR strap is paired — mark unavailable
+        # rather than report a misleading "0 bpm".
+        value_fn=lambda coord: coord.data.get("heart_rate", 0) or None,
     ),
     WalkingPadSensorEntityDescription(
         device_class=SensorDeviceClass.ENUM,
@@ -126,8 +207,8 @@ FTMS_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         name=None,
         options=list(FTMS_TRAINING_STATUS_NAMES.values()),
         translation_key="walkingpad_training_status",
-        value_fn=lambda status: FTMS_TRAINING_STATUS_NAMES.get(
-            status.get("training_status", 0), "other"
+        value_fn=lambda coord: FTMS_TRAINING_STATUS_NAMES.get(
+            coord.data.get("training_status", 0), "other"
         ),
     ),
     WalkingPadSensorEntityDescription(
@@ -138,9 +219,20 @@ FTMS_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         name=None,
         options=list(FTMS_FM_EVENT_NAMES.values()),
         translation_key="walkingpad_last_event",
-        value_fn=lambda status: FTMS_FM_EVENT_NAMES.get(
-            status.get("last_fm_event", 0), "none"
+        value_fn=lambda coord: FTMS_FM_EVENT_NAMES.get(
+            coord.data.get("last_fm_event", 0), "none"
         ),
+    ),
+    # Static device-info: firmware version is FTMS-only because it's
+    # read from Software Revision String (0x2A28) during connect.
+    WalkingPadSensorEntityDescription(
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:chip",
+        key="walkingpad_firmware_version",
+        name=None,
+        static=True,
+        translation_key="walkingpad_firmware_version",
+        value_fn=lambda coord: coord.walkingpad_device.firmware_version or None,
     ),
 )
 
@@ -199,9 +291,16 @@ class WalkingPadSensor(
     @property
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
-        return self.entity_description.value_fn(self.coordinator.data)
+        return self.entity_description.value_fn(self.coordinator)
 
     @property
     def available(self) -> bool:
-        """Return if entity is available."""
+        """Return if entity is available.
+
+        Static device-info sensors (firmware version, protocol, speed
+        range) stay available even when the BLE link is down — their
+        value doesn't depend on a live connection.
+        """
+        if self.entity_description.static:
+            return True
         return self.coordinator.connected

--- a/custom_components/king_smith/sensor.py
+++ b/custom_components/king_smith/sensor.py
@@ -160,6 +160,8 @@ class WalkingPadSensor(
             identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
             name=coordinator.walkingpad_device.name,
             manufacturer="KingSmith",
+            model=coordinator.walkingpad_device.name,
+            sw_version=coordinator.walkingpad_device.firmware_version or None,
         )
 
     @property

--- a/custom_components/king_smith/sensor.py
+++ b/custom_components/king_smith/sensor.py
@@ -23,7 +23,6 @@ from . import WalkingPadIntegrationData
 from .const import (
     DOMAIN,
     FTMS_FM_EVENT_NAMES,
-    FTMS_TRAINING_STATUS_NAMES,
     BeltState,
     ProtocolType,
     WalkingPadMode,
@@ -199,18 +198,12 @@ FTMS_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         # rather than report a misleading "0 bpm".
         value_fn=lambda coord: coord.data.get("heart_rate", 0) or None,
     ),
-    WalkingPadSensorEntityDescription(
-        device_class=SensorDeviceClass.ENUM,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:run",
-        key="walkingpad_training_status",
-        name=None,
-        options=list(FTMS_TRAINING_STATUS_NAMES.values()),
-        translation_key="walkingpad_training_status",
-        value_fn=lambda coord: FTMS_TRAINING_STATUS_NAMES.get(
-            coord.data.get("training_status", 0), "other"
-        ),
-    ),
+    # Training Status sensor was removed — walkingpad-controller 0.4.6
+    # no longer subscribes to Training Status (0x2AD3) on connect to
+    # cut a CCCD write off the connect path on marginal-signal hardware
+    # (see https://github.com/mcdax/walkingpad-controller/releases/tag/v0.4.6).
+    # The field remains in the coord data structure (defaulted to 0)
+    # so a future opt-in re-subscribe doesn't need a coord-API change.
     WalkingPadSensorEntityDescription(
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/king_smith/sensor.py
+++ b/custom_components/king_smith/sensor.py
@@ -121,7 +121,7 @@ COMMON_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
         icon="mdi:bluetooth",
         key="walkingpad_protocol",
         name=None,
-        options=["ftms", "wilink", "unknown"],
+        options=["ftms", "wilink", "sperax", "unknown"],
         static=True,
         translation_key="walkingpad_protocol",
         value_fn=lambda coord: coord.walkingpad_device.protocol.value,
@@ -229,6 +229,30 @@ FTMS_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
     ),
 )
 
+# Sensors only available for Sperax (WLT6200) devices — read-only live
+# read-outs of the incline and vibration level, mirroring the "Current speed"
+# sensor that accompanies the speed control.
+SPERAX_SENSORS: tuple[WalkingPadSensorEntityDescription, ...] = (
+    WalkingPadSensorEntityDescription(
+        icon="mdi:slope-uphill",
+        key="walkingpad_current_incline",
+        name=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        translation_key="walkingpad_current_incline",
+        value_fn=lambda coord: coord.data.get("incline", 0),
+    ),
+    WalkingPadSensorEntityDescription(
+        icon="mdi:vibrate",
+        key="walkingpad_current_vibration",
+        name=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        translation_key="walkingpad_current_vibration",
+        value_fn=lambda coord: coord.data.get("vibration_level", 0),
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -245,6 +269,8 @@ async def async_setup_entry(
 
     if device.protocol == ProtocolType.FTMS:
         sensors.extend(FTMS_SENSORS)
+    elif device.protocol == ProtocolType.SPERAX:
+        sensors.extend(SPERAX_SENSORS)
 
     async_add_entities(
         WalkingPadSensor(coordinator, description) for description in sensors

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -77,6 +77,16 @@ class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
     _temporary_belt_state: TemporaryValue[BeltState]
     _temporary_mode: TemporaryValue[WalkingPadMode]
 
+    @property
+    def available(self) -> bool:
+        """The belt switch is unavailable while the BLE link is down.
+
+        Without a live link we can't drive the belt; an "on" toggle would
+        silently no-op. The user has the Stay-connected switch and the
+        speed slider (which auto-connects) for offline interactions.
+        """
+        return self.coordinator.connected
+
     @staticmethod
     def _create_entity_description(translation_key: str) -> SwitchEntityDescription:
         """Create an entity description with the given translation key."""
@@ -94,11 +104,12 @@ class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
         self._temporary_mode = TemporaryValue[WalkingPadMode]()
         self.coordinator = coordinator
         self.entity_description = self._create_entity_description(
-            "walkingpad_belt_switch"
+            "walkingpad_belt"
         )
         self._attr_unique_id = (
             f"{coordinator.walkingpad_device.mac}-{self.entity_description.key}"
         )
+        self._attr_suggested_object_id = SWITCH_KEY
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
             name=coordinator.walkingpad_device.name,
@@ -162,8 +173,12 @@ class WalkingPadBeltSwitchManual(WalkingPadBeltSwitchBase):
     def __init__(self, coordinator: WalkingPadCoordinator):
         """Initialize the belt switch."""
         super().__init__(coordinator)
+        # Use the unified "Belt" translation_key. The mode (manual vs auto)
+        # is internal config — surfacing it in the entity name has caused
+        # confusion when the entity_id, friendly_name, and translation_key
+        # diverge after a mode change.
         self.entity_description = self._create_entity_description(
-            "walkingpad_belt_switch_manual"
+            "walkingpad_belt"
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -198,7 +213,7 @@ class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):
         """Initialize the belt switch."""
         super().__init__(coordinator)
         self.entity_description = self._create_entity_description(
-            "walkingpad_belt_switch_auto"
+            "walkingpad_belt"
         )
 
     @property
@@ -265,6 +280,7 @@ class WalkingPadStayConnectedSwitch(SwitchEntity, RestoreEntity):
         self._attr_unique_id = (
             f"{coordinator.walkingpad_device.mac}-{self.entity_description.key}"
         )
+        self._attr_suggested_object_id = STAY_CONNECTED_KEY
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
             name=coordinator.walkingpad_device.name,

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -110,6 +110,8 @@ class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
             identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
             name=coordinator.walkingpad_device.name,
             manufacturer="KingSmith",
+            model=coordinator.walkingpad_device.name,
+            sw_version=coordinator.walkingpad_device.firmware_version or None,
         )
         super().__init__()
 
@@ -284,6 +286,8 @@ class WalkingPadStayConnectedSwitch(SwitchEntity, RestoreEntity):
             identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
             name=coordinator.walkingpad_device.name,
             manufacturer="KingSmith",
+            model=coordinator.walkingpad_device.name,
+            sw_version=coordinator.walkingpad_device.firmware_version or None,
         )
         super().__init__()
 

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -93,13 +93,14 @@ class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
 
     @property
     def available(self) -> bool:
-        """The belt switch is unavailable while the BLE link is down.
+        """The belt switch stays available even while the BLE link is down.
 
-        Without a live link we can't drive the belt; an "on" toggle would
-        silently no-op. The user has the Stay-connected switch and the
-        speed slider (which auto-connects) for offline interactions.
+        Tapping it triggers the WalkingPad wrapper's connect-and-issue
+        sequence (same pattern as the speed slider), so the user can
+        start/stop the belt directly from the toggle without first
+        re-enabling Stay-connected. Mirrors the slider's #9 behavior.
         """
-        return self.coordinator.connected
+        return True
 
     @staticmethod
     def _create_entity_description(translation_key: str) -> SwitchEntityDescription:

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -1,6 +1,6 @@
 """Walkingpad switch support."""
 
-import asyncio
+import logging
 from abc import ABC
 from typing import Any
 
@@ -10,9 +10,11 @@ from homeassistant.components.switch import (
     SwitchEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import WalkingPadIntegrationData
 from .const import (
@@ -27,15 +29,35 @@ from .const import (
 from .coordinator import STATUS_UPDATE_INTERVAL, WalkingPadCoordinator
 from .utils import TemporaryValue
 
+_LOGGER = logging.getLogger(__name__)
+
 SWITCH_KEY = "walkingpad_belt_switch"
+STAY_CONNECTED_KEY = "walkingpad_stay_connected"
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the WalkingPad switch."""
+    entry_data: WalkingPadIntegrationData = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry_data["coordinator"]
 
-    if not entry.options.get(CONF_REMOTE_CONTROL_ENABLED, False):
+    entities: list[SwitchEntity] = []
+
+    # Stay Connected switch is always created (not gated by remote_control)
+    entities.append(WalkingPadStayConnectedSwitch(coordinator))
+
+    # Belt control switches are gated by remote_control_enabled
+    if entry.options.get(CONF_REMOTE_CONTROL_ENABLED, False):
+        preferred_mode = entry.options.get(CONF_PREFERRED_MODE, DEFAULT_PREFERRED_MODE)
+        manual_mode = WalkingPadMode.MANUAL.name.lower()
+
+        if preferred_mode == manual_mode:
+            entities.append(WalkingPadBeltSwitchManual(coordinator))
+        else:
+            entities.append(WalkingPadBeltSwitchAuto(coordinator))
+    else:
+        # Clean up belt switch entity if remote_control was disabled
         entity_registry = er.async_get(hass)
         mac_address = entry.data.get(CONF_MAC)
         unique_id = f"{mac_address}-{SWITCH_KEY}"
@@ -43,18 +65,8 @@ async def async_setup_entry(
         entity_id = entity_registry.async_get_entity_id("switch", DOMAIN, unique_id)
         if entity_id:
             entity_registry.async_remove(entity_id)
-        return
 
-    entry_data: WalkingPadIntegrationData = hass.data[DOMAIN][entry.entry_id]
-    coordinator = entry_data["coordinator"]
-
-    preferred_mode = entry.options.get(CONF_PREFERRED_MODE, DEFAULT_PREFERRED_MODE)
-    manual_mode = WalkingPadMode.MANUAL.name.lower()
-
-    if preferred_mode == manual_mode:
-        async_add_entities([WalkingPadBeltSwitchManual(coordinator)])
-    else:
-        async_add_entities([WalkingPadBeltSwitchAuto(coordinator)])
+    async_add_entities(entities)
 
 
 class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
@@ -86,6 +98,11 @@ class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
         )
         self._attr_unique_id = (
             f"{coordinator.walkingpad_device.mac}-{self.entity_description.key}"
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
+            name=coordinator.walkingpad_device.name,
+            manufacturer="KingSmith",
         )
         super().__init__()
 
@@ -149,18 +166,22 @@ class WalkingPadBeltSwitchManual(WalkingPadBeltSwitchBase):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        current_mode = self.coordinator.data.get("mode")
-        if current_mode != WalkingPadMode.MANUAL:
-            await self.coordinator.walkingpad_device.switch_mode(WalkingPadMode.MANUAL)
-            await asyncio.sleep(1.5)
         self.set_temporary_mode(WalkingPadMode.MANUAL)
         self.set_temporary_belt_state(BeltState.STARTING)
-        await self.coordinator.walkingpad_device.start_belt()
+        await self.coordinator.async_set_stay_connected(True)
+        current_mode = self.coordinator.data.get("mode")
+        if current_mode != WalkingPadMode.MANUAL:
+            await self.coordinator.walkingpad_device.start_belt_in_mode(
+                WalkingPadMode.MANUAL
+            )
+        else:
+            await self.coordinator.walkingpad_device.start_belt()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         self.set_temporary_belt_state(BeltState.STOPPED)
         await self.coordinator.walkingpad_device.stop_belt()
+        self.coordinator.async_schedule_deferred_disconnect()
 
 
 class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):
@@ -196,6 +217,7 @@ class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         self.set_temporary_mode(WalkingPadMode.AUTO)
+        await self.coordinator.async_set_stay_connected(True)
         await self.coordinator.walkingpad_device.switch_mode(WalkingPadMode.AUTO)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -203,3 +225,83 @@ class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):
         self.set_temporary_mode(WalkingPadMode.STANDBY)
         self.set_temporary_belt_state(BeltState.STOPPED)
         await self.coordinator.walkingpad_device.switch_mode(WalkingPadMode.STANDBY)
+        self.coordinator.async_schedule_deferred_disconnect()
+
+
+class WalkingPadStayConnectedSwitch(SwitchEntity, RestoreEntity):
+    """Switch to control whether HA maintains a persistent BLE connection.
+
+    When ON (default): HA stays connected, coordinator polls every 5s, sensors
+    update live.  This is the normal behavior.
+
+    When OFF: HA disconnects immediately, freeing the BLE link so the user's
+    smartphone app (e.g. KS Fit) can connect for tracking.  Commands (belt
+    on/off, speed) will still work — they connect, send the command, then
+    disconnect right away.  Sensors go stale until stay_connected is re-enabled.
+
+    State is persisted across HA restarts via RestoreEntity.
+    """
+
+    entity_description: SwitchEntityDescription
+
+    def __init__(self, coordinator: WalkingPadCoordinator) -> None:
+        """Initialize the stay connected switch."""
+        self.coordinator = coordinator
+        self.entity_description = SwitchEntityDescription(
+            device_class=SwitchDeviceClass.SWITCH,
+            icon="mdi:bluetooth-connect",
+            key=STAY_CONNECTED_KEY,
+            translation_key=STAY_CONNECTED_KEY,
+            has_entity_name=True,
+        )
+        self._attr_unique_id = (
+            f"{coordinator.walkingpad_device.mac}-{self.entity_description.key}"
+        )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.walkingpad_device.mac)},
+            name=coordinator.walkingpad_device.name,
+            manufacturer="KingSmith",
+        )
+        super().__init__()
+
+    @property
+    def is_on(self) -> bool:
+        """Return the live stay_connected state from the device."""
+        return self.coordinator.walkingpad_device.stay_connected
+
+    async def async_added_to_hass(self) -> None:
+        """Restore state after HA restart and subscribe to coordinator updates."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            restored = last_state.state == "on"
+            _LOGGER.info(
+                "Restoring stay_connected state: %s (was %s)",
+                restored,
+                last_state.state,
+            )
+            self.coordinator.walkingpad_device.stay_connected = restored
+        else:
+            _LOGGER.info("No previous stay_connected state, defaulting to ON")
+            self.coordinator.walkingpad_device.stay_connected = True
+
+        # Subscribe to coordinator updates so our UI state refreshes when
+        # belt switches toggle stay_connected via the coordinator.
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_coordinator_update)
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """React to coordinator data updates by refreshing our HA state."""
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on — re-enable persistent BLE connection."""
+        await self.coordinator.async_set_stay_connected(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off — disconnect BLE to free link for phone app."""
+        await self.coordinator.async_set_stay_connected(False)
+        self.async_write_ha_state()

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -77,6 +77,20 @@ class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
     _temporary_belt_state: TemporaryValue[BeltState]
     _temporary_mode: TemporaryValue[WalkingPadMode]
 
+    # We push state updates from the coordinator listener; HA polling would
+    # otherwise lag the belt-state by many seconds after a slider drag, so
+    # the toggle would stay in the wrong position until the next poll.
+    _attr_should_poll = False
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to coordinator updates so is_on re-evaluates promptly
+        whenever the underlying belt_state changes — matching how the
+        "Zustand" sensor refreshes."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
     @property
     def available(self) -> bool:
         """The belt switch is unavailable while the BLE link is down.

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -93,6 +93,13 @@ class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
         self._temporary_belt_state = TemporaryValue[BeltState]()
         self._temporary_mode = TemporaryValue[WalkingPadMode]()
         self.coordinator = coordinator
+        # Tracks whether the user's stay_connected preference was True
+        # before async_turn_on forced it to True for the duration of the
+        # walk.  Only the explicit False case (user wants connect-per-
+        # command, the belt switch had to flip it on for the walk) gets
+        # an auto-disconnect on stop; True or None (HA restarted mid-walk,
+        # no observation) leaves the toggle alone.
+        self._stay_connected_was_true: bool | None = None
         self.entity_description = self._create_entity_description(
             "walkingpad_belt_switch"
         )
@@ -168,6 +175,9 @@ class WalkingPadBeltSwitchManual(WalkingPadBeltSwitchBase):
         """Turn the switch on."""
         self.set_temporary_mode(WalkingPadMode.MANUAL)
         self.set_temporary_belt_state(BeltState.STARTING)
+        self._stay_connected_was_true = (
+            self.coordinator.walkingpad_device.stay_connected
+        )
         await self.coordinator.async_set_stay_connected(True)
         current_mode = self.coordinator.data.get("mode")
         if current_mode != WalkingPadMode.MANUAL:
@@ -181,7 +191,12 @@ class WalkingPadBeltSwitchManual(WalkingPadBeltSwitchBase):
         """Turn the switch off."""
         self.set_temporary_belt_state(BeltState.STOPPED)
         await self.coordinator.walkingpad_device.stop_belt()
-        self.coordinator.async_schedule_deferred_disconnect()
+        # Only auto-disconnect after stop if stay_connected wasn't the
+        # user's persistent preference — i.e. async_turn_on observed it
+        # as False and flipped it on for this walk.  When the observation
+        # is True or missing (HA restart mid-walk), leave the toggle alone.
+        if self._stay_connected_was_true is False:
+            self.coordinator.async_schedule_deferred_disconnect()
 
 
 class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):
@@ -217,6 +232,9 @@ class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         self.set_temporary_mode(WalkingPadMode.AUTO)
+        self._stay_connected_was_true = (
+            self.coordinator.walkingpad_device.stay_connected
+        )
         await self.coordinator.async_set_stay_connected(True)
         await self.coordinator.walkingpad_device.switch_mode(WalkingPadMode.AUTO)
 
@@ -225,7 +243,12 @@ class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):
         self.set_temporary_mode(WalkingPadMode.STANDBY)
         self.set_temporary_belt_state(BeltState.STOPPED)
         await self.coordinator.walkingpad_device.switch_mode(WalkingPadMode.STANDBY)
-        self.coordinator.async_schedule_deferred_disconnect()
+        # Only auto-disconnect after stop if stay_connected wasn't the
+        # user's persistent preference — i.e. async_turn_on observed it
+        # as False and flipped it on for this walk.  When the observation
+        # is True or missing (HA restart mid-walk), leave the toggle alone.
+        if self._stay_connected_was_true is False:
+            self.coordinator.async_schedule_deferred_disconnect()
 
 
 class WalkingPadStayConnectedSwitch(SwitchEntity, RestoreEntity):

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -93,13 +93,6 @@ class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
         self._temporary_belt_state = TemporaryValue[BeltState]()
         self._temporary_mode = TemporaryValue[WalkingPadMode]()
         self.coordinator = coordinator
-        # Tracks whether the user's stay_connected preference was True
-        # before async_turn_on forced it to True for the duration of the
-        # walk.  Only the explicit False case (user wants connect-per-
-        # command, the belt switch had to flip it on for the walk) gets
-        # an auto-disconnect on stop; True or None (HA restarted mid-walk,
-        # no observation) leaves the toggle alone.
-        self._stay_connected_was_true: bool | None = None
         self.entity_description = self._create_entity_description(
             "walkingpad_belt_switch"
         )
@@ -174,13 +167,16 @@ class WalkingPadBeltSwitchManual(WalkingPadBeltSwitchBase):
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
+        """Turn the switch on.
+
+        Stay-connected is left as the user set it.  If they had it off,
+        the WalkingPad library will connect for the start command and
+        disconnect right after; the belt will keep running but live
+        sensors will go stale until the user manually re-enables
+        Stay-connected.
+        """
         self.set_temporary_mode(WalkingPadMode.MANUAL)
         self.set_temporary_belt_state(BeltState.STARTING)
-        self._stay_connected_was_true = (
-            self.coordinator.walkingpad_device.stay_connected
-        )
-        await self.coordinator.async_set_stay_connected(True)
         current_mode = self.coordinator.data.get("mode")
         if current_mode != WalkingPadMode.MANUAL:
             await self.coordinator.walkingpad_device.start_belt_in_mode(
@@ -190,15 +186,9 @@ class WalkingPadBeltSwitchManual(WalkingPadBeltSwitchBase):
             await self.coordinator.walkingpad_device.start_belt()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
+        """Turn the switch off.  Stay-connected is left untouched."""
         self.set_temporary_belt_state(BeltState.STOPPED)
         await self.coordinator.walkingpad_device.stop_belt()
-        # Only auto-disconnect after stop if stay_connected wasn't the
-        # user's persistent preference — i.e. async_turn_on observed it
-        # as False and flipped it on for this walk.  When the observation
-        # is True or missing (HA restart mid-walk), leave the toggle alone.
-        if self._stay_connected_was_true is False:
-            self.coordinator.async_schedule_deferred_disconnect()
 
 
 class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):
@@ -232,25 +222,18 @@ class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):
         return belt_state in [BeltState.ACTIVE, BeltState.STARTING]
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
+        """Turn the switch on (auto mode).  Stay-connected is left untouched."""
         self.set_temporary_mode(WalkingPadMode.AUTO)
-        self._stay_connected_was_true = (
-            self.coordinator.walkingpad_device.stay_connected
-        )
-        await self.coordinator.async_set_stay_connected(True)
         await self.coordinator.walkingpad_device.switch_mode(WalkingPadMode.AUTO)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
+        """Turn the switch off (auto mode → standby).
+
+        Stay-connected is left untouched — fully under the user's control.
+        """
         self.set_temporary_mode(WalkingPadMode.STANDBY)
         self.set_temporary_belt_state(BeltState.STOPPED)
         await self.coordinator.walkingpad_device.switch_mode(WalkingPadMode.STANDBY)
-        # Only auto-disconnect after stop if stay_connected wasn't the
-        # user's persistent preference — i.e. async_turn_on observed it
-        # as False and flipped it on for this walk.  When the observation
-        # is True or missing (HA restart mid-walk), leave the toggle alone.
-        if self._stay_connected_was_true is False:
-            self.coordinator.async_schedule_deferred_disconnect()
 
 
 class WalkingPadStayConnectedSwitch(SwitchEntity, RestoreEntity):
@@ -312,8 +295,8 @@ class WalkingPadStayConnectedSwitch(SwitchEntity, RestoreEntity):
             _LOGGER.info("No previous stay_connected state, defaulting to ON")
             self.coordinator.walkingpad_device.stay_connected = True
 
-        # Subscribe to coordinator updates so our UI state refreshes when
-        # belt switches toggle stay_connected via the coordinator.
+        # Subscribe to coordinator updates so our UI state refreshes
+        # whenever the underlying stay_connected flag changes.
         self.async_on_remove(
             self.coordinator.async_add_listener(self._handle_coordinator_update)
         )

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -216,9 +216,21 @@ class WalkingPadBeltSwitchManual(WalkingPadBeltSwitchBase):
             await self.coordinator.walkingpad_device.start_belt()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off.  Stay-connected is left untouched."""
+        """Turn the switch off — sends PAUSE, not STOP.
+
+        The phone app and the physical remote pause when the user presses
+        their stop button: the device decelerates to zero but the session
+        counters (time, distance, calories, steps) carry over so a
+        subsequent toggle-on resumes from where the user left off.
+
+        ``stop_belt()`` (the hard reset that zeros counters) is still
+        available on the WalkingPad wrapper if a custom action / service
+        wants it — it's intentionally not on the default toggle because
+        most users expect the toggle to behave like the app does.
+        Stay-connected is left untouched.
+        """
         self.set_temporary_belt_state(BeltState.STOPPED)
-        await self.coordinator.walkingpad_device.stop_belt()
+        await self.coordinator.walkingpad_device.pause_belt()
 
 
 class WalkingPadBeltSwitchAuto(WalkingPadBeltSwitchBase):

--- a/custom_components/king_smith/translations/de.json
+++ b/custom_components/king_smith/translations/de.json
@@ -84,6 +84,12 @@
             "walkingpad_calories": {
                 "name": "Kalorien"
             },
+            "walkingpad_calories_per_hour": {
+                "name": "Kalorienrate"
+            },
+            "walkingpad_heart_rate": {
+                "name": "Herzfrequenz"
+            },
             "walkingpad_state": {
                 "name": "Zustand"
             },
@@ -95,6 +101,26 @@
             },
             "walkingpad_last_event": {
                 "name": "Letztes FTMS-Ereignis"
+            },
+            "walkingpad_firmware_version": {
+                "name": "Firmware-Version"
+            },
+            "walkingpad_protocol": {
+                "name": "Protokoll"
+            },
+            "walkingpad_min_speed": {
+                "name": "Min. Geschwindigkeit"
+            },
+            "walkingpad_max_speed": {
+                "name": "Max. Geschwindigkeit"
+            },
+            "walkingpad_speed_increment": {
+                "name": "Geschwindigkeitsschritt"
+            }
+        },
+        "binary_sensor": {
+            "walkingpad_connected": {
+                "name": "Verbunden"
             }
         },
         "switch": {

--- a/custom_components/king_smith/translations/de.json
+++ b/custom_components/king_smith/translations/de.json
@@ -91,22 +91,73 @@
                 "name": "Herzfrequenz"
             },
             "walkingpad_state": {
-                "name": "Zustand"
+                "name": "Zustand",
+                "state": {
+                    "stopped": "Gestoppt",
+                    "active": "Aktiv",
+                    "standby": "Standby",
+                    "starting": "Startet",
+                    "unknown": "Unbekannt"
+                }
             },
             "walkingpad_mode": {
-                "name": "Modus"
+                "name": "Modus",
+                "state": {
+                    "auto": "Automatik",
+                    "manual": "Manuell",
+                    "standby": "Standby"
+                }
             },
             "walkingpad_training_status": {
-                "name": "Trainingsstatus"
+                "name": "Trainingsstatus",
+                "state": {
+                    "other": "Sonstiges",
+                    "idle": "Im Leerlauf",
+                    "warming_up": "Aufwärmen",
+                    "low_intensity_interval": "Intervall mit geringer Intensität",
+                    "high_intensity_interval": "Intervall mit hoher Intensität",
+                    "recovery_interval": "Erholungsintervall",
+                    "iso_metric": "Iso-metrisch",
+                    "heart_rate_control": "Herzfrequenz-Kontrolle",
+                    "fitness_test": "Fitness-Test",
+                    "speed_out_of_control": "Geschwindigkeit außer Kontrolle",
+                    "cool_down": "Cool-down",
+                    "watt_control": "Watt-Kontrolle",
+                    "manual_mode": "Manueller Modus",
+                    "pre_workout": "Vor dem Training",
+                    "post_workout": "Nach dem Training"
+                }
             },
             "walkingpad_last_event": {
-                "name": "Letztes FTMS-Ereignis"
+                "name": "Letztes FTMS-Ereignis",
+                "state": {
+                    "none": "Keines",
+                    "reset": "Reset",
+                    "stopped_or_paused": "Gestoppt oder pausiert",
+                    "stopped_by_safety_key": "Gestoppt durch Sicherheitsschlüssel",
+                    "started_or_resumed": "Gestartet oder fortgesetzt",
+                    "target_speed_changed": "Zielgeschwindigkeit geändert",
+                    "target_inclination_changed": "Zielneigung geändert",
+                    "target_resistance_changed": "Zielwiderstand geändert",
+                    "target_power_changed": "Zielleistung geändert",
+                    "target_heart_rate_changed": "Ziel-Herzfrequenz geändert",
+                    "target_expended_energy_changed": "Ziel-Energieverbrauch geändert",
+                    "target_time_changed": "Zielzeit geändert",
+                    "spin_down_status": "Spin-down-Status",
+                    "target_cadence_changed": "Ziel-Trittfrequenz geändert",
+                    "control_permission_lost": "Steuerungsberechtigung verloren"
+                }
             },
             "walkingpad_firmware_version": {
                 "name": "Firmware-Version"
             },
             "walkingpad_protocol": {
-                "name": "Protokoll"
+                "name": "Protokoll",
+                "state": {
+                    "ftms": "FTMS",
+                    "wilink": "WiLink (Legacy)",
+                    "unknown": "Unbekannt"
+                }
             },
             "walkingpad_min_speed": {
                 "name": "Min. Geschwindigkeit"
@@ -124,14 +175,8 @@
             }
         },
         "switch": {
-            "walkingpad_belt_switch": {
+            "walkingpad_belt": {
                 "name": "Laufband"
-            },
-            "walkingpad_belt_switch_manual": {
-                "name": "Laufband (manueller Modus)"
-            },
-            "walkingpad_belt_switch_auto": {
-                "name": "Laufband (Auto-Modus)"
             },
             "walkingpad_stay_connected": {
                 "name": "Verbunden bleiben"

--- a/custom_components/king_smith/translations/de.json
+++ b/custom_components/king_smith/translations/de.json
@@ -89,6 +89,12 @@
             },
             "walkingpad_mode": {
                 "name": "Modus"
+            },
+            "walkingpad_training_status": {
+                "name": "Trainingsstatus"
+            },
+            "walkingpad_last_event": {
+                "name": "Letztes FTMS-Ereignis"
             }
         },
         "switch": {

--- a/custom_components/king_smith/translations/de.json
+++ b/custom_components/king_smith/translations/de.json
@@ -1,0 +1,114 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Dieses Geraet ist bereits konfiguriert"
+        },
+        "error": {
+            "cannot_connect": "Verbindung fehlgeschlagen",
+            "unknown": "Unerwarteter Fehler"
+        },
+        "step": {
+            "device": {
+                "data": {
+                    "mac": "Geraet",
+                    "name": "Name"
+                },
+                "sections": {
+                    "remote_control": {
+                        "name": "Fernsteuerung",
+                        "description": "Die Fernsteuerung deines WalkingPads kann gefaehrliche Situationen fuer dich oder deine Umgebung schaffen. Aktiviere diese Option nur, wenn du weisst, was du tust. Benutzung auf eigene Gefahr.",
+                        "data": {
+                            "remote_control_enabled": "Fernsteuerung aktivieren",
+                            "preferred_mode": "Bevorzugter Modus"
+                        }
+                    }
+                },
+                "description": "Dein WalkingPad wurde automatisch erkannt. Bitte gib ihm einen Namen fuer Home Assistant.",
+                "title": "Walkingpad"
+            },
+            "user": {
+                "data": {
+                    "mac": "Geraet",
+                    "name": "Name"
+                },
+                "data_description": {
+                    "mac": "Die MAC-Adresse deines Walkingpads."
+                },
+                "sections": {
+                    "remote_control": {
+                        "name": "Fernsteuerung",
+                        "description": "Die Fernsteuerung deines WalkingPads kann gefaehrliche Situationen fuer dich oder deine Umgebung schaffen. Aktiviere diese Option nur, wenn du weisst, was du tust. Benutzung auf eigene Gefahr.",
+                        "data": {
+                            "remote_control_enabled": "Fernsteuerung aktivieren",
+                            "preferred_mode": "Bevorzugter Modus"
+                        }
+                    }
+                },
+                "description": "Wenn dein Walkingpad eingeschaltet ist, sollte es automatisch von Home Assistant erkannt werden. Verwende die manuelle Konfiguration nur, wenn du weisst, was du tust.",
+                "title": "Manuelle Konfiguration eines Walkingpads"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "WalkingPad-Optionen",
+                "description": "Fernsteuerungseinstellungen fuer dein WalkingPad konfigurieren.",
+                "sections": {
+                    "remote_control": {
+                        "name": "Fernsteuerung",
+                        "description": "Die Fernsteuerung deines WalkingPads kann gefaehrliche Situationen fuer dich oder deine Umgebung schaffen. Aktiviere diese Option nur, wenn du weisst, was du tust. Benutzung auf eigene Gefahr.",
+                        "data": {
+                            "remote_control_enabled": "Fernsteuerung aktivieren",
+                            "preferred_mode": "Bevorzugter Modus"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "walkingpad_current_speed": {
+                "name": "Aktuelle Geschwindigkeit"
+            },
+            "walkingpad_distance": {
+                "name": "Distanz"
+            },
+            "walkingpad_duration": {
+                "name": "Dauer"
+            },
+            "walkingpad_steps": {
+                "name": "Schritte"
+            },
+            "walkingpad_calories": {
+                "name": "Kalorien"
+            },
+            "walkingpad_state": {
+                "name": "Zustand"
+            },
+            "walkingpad_mode": {
+                "name": "Modus"
+            }
+        },
+        "switch": {
+            "walkingpad_belt_switch": {
+                "name": "Laufband"
+            },
+            "walkingpad_belt_switch_manual": {
+                "name": "Laufband (manueller Modus)"
+            },
+            "walkingpad_belt_switch_auto": {
+                "name": "Laufband (Auto-Modus)"
+            },
+            "walkingpad_stay_connected": {
+                "name": "Verbunden bleiben"
+            }
+        },
+        "number": {
+            "walkingpad_speed": {
+                "name": "Geschwindigkeit"
+            }
+        }
+    }
+}

--- a/custom_components/king_smith/translations/de.json
+++ b/custom_components/king_smith/translations/de.json
@@ -95,6 +95,7 @@
                 "state": {
                     "stopped": "Gestoppt",
                     "active": "Aktiv",
+                    "paused": "Pausiert",
                     "standby": "Standby",
                     "starting": "Startet",
                     "unknown": "Unbekannt"
@@ -185,6 +186,11 @@
         "number": {
             "walkingpad_speed": {
                 "name": "Geschwindigkeit"
+            }
+        },
+        "button": {
+            "walkingpad_stop_session": {
+                "name": "Stopp"
             }
         }
     }

--- a/custom_components/king_smith/translations/de.json
+++ b/custom_components/king_smith/translations/de.json
@@ -72,6 +72,12 @@
             "walkingpad_current_speed": {
                 "name": "Aktuelle Geschwindigkeit"
             },
+            "walkingpad_current_incline": {
+                "name": "Aktuelle Neigung"
+            },
+            "walkingpad_current_vibration": {
+                "name": "Aktuelle Vibration"
+            },
             "walkingpad_distance": {
                 "name": "Distanz"
             },
@@ -157,6 +163,7 @@
                 "state": {
                     "ftms": "FTMS",
                     "wilink": "WiLink (Legacy)",
+                    "sperax": "Sperax",
                     "unknown": "Unbekannt"
                 }
             },
@@ -186,11 +193,20 @@
         "number": {
             "walkingpad_speed": {
                 "name": "Geschwindigkeit"
+            },
+            "walkingpad_incline": {
+                "name": "Neigung"
+            },
+            "walkingpad_vibration": {
+                "name": "Vibration"
             }
         },
         "button": {
             "walkingpad_stop_session": {
                 "name": "Stopp"
+            },
+            "walkingpad_reconnect": {
+                "name": "Neu verbinden"
             }
         }
     }

--- a/custom_components/king_smith/translations/en.json
+++ b/custom_components/king_smith/translations/en.json
@@ -89,6 +89,12 @@
             },
             "walkingpad_mode": {
                 "name": "Mode"
+            },
+            "walkingpad_training_status": {
+                "name": "Training status"
+            },
+            "walkingpad_last_event": {
+                "name": "Last FTMS event"
             }
         },
         "switch": {

--- a/custom_components/king_smith/translations/en.json
+++ b/custom_components/king_smith/translations/en.json
@@ -84,6 +84,12 @@
             "walkingpad_calories": {
                 "name": "Calories"
             },
+            "walkingpad_calories_per_hour": {
+                "name": "Calorie rate"
+            },
+            "walkingpad_heart_rate": {
+                "name": "Heart rate"
+            },
             "walkingpad_state": {
                 "name": "State"
             },
@@ -95,6 +101,26 @@
             },
             "walkingpad_last_event": {
                 "name": "Last FTMS event"
+            },
+            "walkingpad_firmware_version": {
+                "name": "Firmware version"
+            },
+            "walkingpad_protocol": {
+                "name": "Protocol"
+            },
+            "walkingpad_min_speed": {
+                "name": "Min speed"
+            },
+            "walkingpad_max_speed": {
+                "name": "Max speed"
+            },
+            "walkingpad_speed_increment": {
+                "name": "Speed increment"
+            }
+        },
+        "binary_sensor": {
+            "walkingpad_connected": {
+                "name": "Connected"
             }
         },
         "switch": {

--- a/custom_components/king_smith/translations/en.json
+++ b/custom_components/king_smith/translations/en.json
@@ -75,17 +75,14 @@
             "walkingpad_distance": {
                 "name": "Distance"
             },
-            "walkingpad_duration_minutes": {
-                "name": "Duration (minutes)"
-            },
-            "walkingpad_duration_hours": {
-                "name": "Duration (hours)"
-            },
-            "walkingpad_duration_days": {
-                "name": "Duration (days)"
+            "walkingpad_duration": {
+                "name": "Duration"
             },
             "walkingpad_steps": {
                 "name": "Steps"
+            },
+            "walkingpad_calories": {
+                "name": "Calories"
             },
             "walkingpad_state": {
                 "name": "State"
@@ -103,6 +100,9 @@
             },
             "walkingpad_belt_switch_auto": {
                 "name": "Belt (auto mode)"
+            },
+            "walkingpad_stay_connected": {
+                "name": "Stay connected"
             }
         },
         "number": {

--- a/custom_components/king_smith/translations/en.json
+++ b/custom_components/king_smith/translations/en.json
@@ -91,22 +91,73 @@
                 "name": "Heart rate"
             },
             "walkingpad_state": {
-                "name": "State"
+                "name": "State",
+                "state": {
+                    "stopped": "Stopped",
+                    "active": "Active",
+                    "standby": "Standby",
+                    "starting": "Starting",
+                    "unknown": "Unknown"
+                }
             },
             "walkingpad_mode": {
-                "name": "Mode"
+                "name": "Mode",
+                "state": {
+                    "auto": "Auto",
+                    "manual": "Manual",
+                    "standby": "Standby"
+                }
             },
             "walkingpad_training_status": {
-                "name": "Training status"
+                "name": "Training status",
+                "state": {
+                    "other": "Other",
+                    "idle": "Idle",
+                    "warming_up": "Warming up",
+                    "low_intensity_interval": "Low-intensity interval",
+                    "high_intensity_interval": "High-intensity interval",
+                    "recovery_interval": "Recovery interval",
+                    "iso_metric": "Iso-metric",
+                    "heart_rate_control": "Heart-rate control",
+                    "fitness_test": "Fitness test",
+                    "speed_out_of_control": "Speed out of control",
+                    "cool_down": "Cool down",
+                    "watt_control": "Watt control",
+                    "manual_mode": "Manual mode",
+                    "pre_workout": "Pre-workout",
+                    "post_workout": "Post-workout"
+                }
             },
             "walkingpad_last_event": {
-                "name": "Last FTMS event"
+                "name": "Last FTMS event",
+                "state": {
+                    "none": "None",
+                    "reset": "Reset",
+                    "stopped_or_paused": "Stopped or paused",
+                    "stopped_by_safety_key": "Stopped by safety key",
+                    "started_or_resumed": "Started or resumed",
+                    "target_speed_changed": "Target speed changed",
+                    "target_inclination_changed": "Target inclination changed",
+                    "target_resistance_changed": "Target resistance changed",
+                    "target_power_changed": "Target power changed",
+                    "target_heart_rate_changed": "Target heart-rate changed",
+                    "target_expended_energy_changed": "Target energy changed",
+                    "target_time_changed": "Target time changed",
+                    "spin_down_status": "Spin-down status",
+                    "target_cadence_changed": "Target cadence changed",
+                    "control_permission_lost": "Control permission lost"
+                }
             },
             "walkingpad_firmware_version": {
                 "name": "Firmware version"
             },
             "walkingpad_protocol": {
-                "name": "Protocol"
+                "name": "Protocol",
+                "state": {
+                    "ftms": "FTMS",
+                    "wilink": "WiLink (legacy)",
+                    "unknown": "Unknown"
+                }
             },
             "walkingpad_min_speed": {
                 "name": "Min speed"
@@ -124,14 +175,8 @@
             }
         },
         "switch": {
-            "walkingpad_belt_switch": {
+            "walkingpad_belt": {
                 "name": "Belt"
-            },
-            "walkingpad_belt_switch_manual": {
-                "name": "Belt (manual mode)"
-            },
-            "walkingpad_belt_switch_auto": {
-                "name": "Belt (auto mode)"
             },
             "walkingpad_stay_connected": {
                 "name": "Stay connected"

--- a/custom_components/king_smith/translations/en.json
+++ b/custom_components/king_smith/translations/en.json
@@ -95,6 +95,7 @@
                 "state": {
                     "stopped": "Stopped",
                     "active": "Active",
+                    "paused": "Paused",
                     "standby": "Standby",
                     "starting": "Starting",
                     "unknown": "Unknown"
@@ -185,6 +186,11 @@
         "number": {
             "walkingpad_speed": {
                 "name": "Speed"
+            }
+        },
+        "button": {
+            "walkingpad_stop_session": {
+                "name": "Stop"
             }
         }
     }

--- a/custom_components/king_smith/translations/en.json
+++ b/custom_components/king_smith/translations/en.json
@@ -72,6 +72,12 @@
             "walkingpad_current_speed": {
                 "name": "Current speed"
             },
+            "walkingpad_current_incline": {
+                "name": "Current incline"
+            },
+            "walkingpad_current_vibration": {
+                "name": "Current vibration"
+            },
             "walkingpad_distance": {
                 "name": "Distance"
             },
@@ -157,6 +163,7 @@
                 "state": {
                     "ftms": "FTMS",
                     "wilink": "WiLink (legacy)",
+                    "sperax": "Sperax",
                     "unknown": "Unknown"
                 }
             },
@@ -186,11 +193,20 @@
         "number": {
             "walkingpad_speed": {
                 "name": "Speed"
+            },
+            "walkingpad_incline": {
+                "name": "Incline"
+            },
+            "walkingpad_vibration": {
+                "name": "Vibration"
             }
         },
         "button": {
             "walkingpad_stop_session": {
                 "name": "Stop"
+            },
+            "walkingpad_reconnect": {
+                "name": "Reconnect"
             }
         }
     }

--- a/custom_components/king_smith/walkingpad.py
+++ b/custom_components/king_smith/walkingpad.py
@@ -28,6 +28,12 @@ from .const import WalkingPadMode, WalkingPadStatus
 
 _LOGGER = logging.getLogger(__name__)
 
+# When stay_connected is OFF, disconnect this many seconds after the most
+# recent action. Bursts of actions (e.g. start_belt immediately followed by
+# set_speed) reset the timer so the BLE link is held for the whole burst,
+# avoiding connect/disconnect churn between them.
+IDLE_DISCONNECT_TIMEOUT_SECONDS = 5.0
+
 
 @unique
 class WalkingPadConnectionStatus(Enum):
@@ -58,9 +64,15 @@ class WalkingPad:
 
         # Stay Connected toggle: when True (default), HA maintains a
         # persistent BLE connection and the coordinator polls every 5s.
-        # When False, HA disconnects immediately after each command, freeing
+        # When False, HA disconnects 5s after the last action, freeing
         # the BLE link so the user's smartphone app can connect.
         self._stay_connected: bool = True
+
+        # Idle-disconnect timer task — schedules a `disconnect()` call
+        # IDLE_DISCONNECT_TIMEOUT_SECONDS after the most recent command,
+        # when stay_connected is False. Each new command cancels the
+        # current timer and (post-command) schedules a fresh one.
+        self._disconnect_timer_task: asyncio.Task[None] | None = None
 
         # Register library callbacks
         self._controller.register_status_callback(self._on_library_status_update)
@@ -154,18 +166,75 @@ class WalkingPad:
     def stay_connected(self, value: bool) -> None:
         """Set the stay_connected preference."""
         self._stay_connected = value
+        # Either direction invalidates a pending idle-disconnect:
+        #   True  → user wants to stay connected, don't drop the link
+        #   False → coordinator's set_stay_connected(False) disconnects
+        #           directly, no need for the deferred timer
+        self._cancel_idle_disconnect()
         _LOGGER.info("Stay connected set to %s", value)
 
     async def disconnect_after_command(self) -> None:
-        """Disconnect immediately if stay_connected is disabled."""
-        if not self._stay_connected:
-            _LOGGER.debug("Stay connected disabled, disconnecting after command")
+        """Schedule a deferred disconnect when stay_connected is OFF.
+
+        Bursts of actions reset the timer, so a sequence like
+        `start_belt -> set_speed` doesn't disconnect-and-reconnect
+        between the two commands. After the timer fires (5s after
+        the last action), we disconnect — unless stay_connected has
+        been turned back on or another action arrived first.
+        """
+        if self._stay_connected:
+            return
+        if not self.connected:
+            return
+        _LOGGER.debug(
+            "Stay connected disabled, scheduling disconnect in %ss",
+            IDLE_DISCONNECT_TIMEOUT_SECONDS,
+        )
+        self._reschedule_idle_disconnect()
+
+    def _reschedule_idle_disconnect(self) -> None:
+        """Cancel any pending idle-disconnect and start a fresh timer."""
+        self._cancel_idle_disconnect()
+        self._disconnect_timer_task = asyncio.create_task(
+            self._idle_disconnect_after_timeout(),
+            name="walkingpad-idle-disconnect",
+        )
+
+    def _cancel_idle_disconnect(self) -> None:
+        """Cancel the idle-disconnect timer if it's pending."""
+        task = self._disconnect_timer_task
+        if task is not None and not task.done():
+            task.cancel()
+        self._disconnect_timer_task = None
+
+    async def _idle_disconnect_after_timeout(self) -> None:
+        """Wait for the idle timeout, then disconnect under the BLE lock."""
+        try:
+            await asyncio.sleep(IDLE_DISCONNECT_TIMEOUT_SECONDS)
+        except asyncio.CancelledError:
+            return
+        # Re-check under the BLE lock so we don't race with a command
+        # that started during the sleep.
+        async with self._ble_lock:
+            if self._stay_connected:
+                _LOGGER.debug("Idle timer fired but stay_connected is on; skipping")
+                return
+            if not self.connected:
+                return
+            _LOGGER.info(
+                "Idle timeout reached after %ss, disconnecting",
+                IDLE_DISCONNECT_TIMEOUT_SECONDS,
+            )
             await self.disconnect()
 
     # --- Connection ---
 
     async def connect(self) -> None:
         """Connect to the device."""
+        # An incoming connection request invalidates any pending
+        # idle-disconnect — we're about to use the link.
+        self._cancel_idle_disconnect()
+
         if self._connection_status == WalkingPadConnectionStatus.CONNECTING:
             _LOGGER.info("Already connecting to WalkingPad")
             return

--- a/custom_components/king_smith/walkingpad.py
+++ b/custom_components/king_smith/walkingpad.py
@@ -1,14 +1,30 @@
-"""Walking Pad Api."""
+"""Walking Pad API - Thin wrapper around walkingpad-controller library.
+
+This module provides a WalkingPad class that wraps the walkingpad-controller
+library's WalkingPadController, adding Home Assistant-specific features:
+  - WalkingPadConnectionStatus enum (for coordinator)
+  - stay_connected toggle (persistent BLE vs. connect-per-command)
+  - Status mapping from TreadmillStatus -> WalkingPadStatus (TypedDict)
+
+Protocol detection, BLE connection, FTMS/WiLink delegation, cold-start
+recovery, and pending speed management are all handled by the library.
+"""
 
 import asyncio
 import logging
 from enum import Enum, unique
 
-from bleak import BleakError
 from bleak.backends.device import BLEDevice
-from ph4_walkingpad.pad import Controller, WalkingPadCurStatus
+from bleak.exc import BleakError
 
-from .const import BeltState, WalkingPadMode, WalkingPadStatus
+from walkingpad_controller import (
+    BeltState,
+    OperatingMode,
+    TreadmillStatus,
+    WalkingPadController,
+)
+
+from .const import WalkingPadMode, WalkingPadStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,62 +39,94 @@ class WalkingPadConnectionStatus(Enum):
 
 
 class WalkingPad:
-    """The WalkingPad device."""
+    """Home Assistant wrapper around WalkingPadController.
+
+    Adds HA-specific features (stay_connected, connection status enum,
+    WalkingPadStatus mapping) on top of the library's unified controller.
+    """
 
     def __init__(self, name: str, ble_device: BLEDevice) -> None:
         """Create a WalkingPad object."""
-
-        self._name = name
-        self._ble_device = ble_device
-        self._controller = Controller()
-        self._controller.log_messages_info = False
+        self._controller = WalkingPadController(ble_device=ble_device, name=name)
         self._callbacks = []
         self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
-        self._register_controller_callbacks()
 
-    def _register_controller_callbacks(self):
-        self._controller.handler_cur_status = self._on_status_update
+        # BLE operation lock — serialises all BLE operations so coordinator
+        # polls cannot interleave with multi-step command sequences
+        # (e.g. switch_mode + sleep + start_belt in manual-mode turn-on).
+        self._ble_lock = asyncio.Lock()
 
-    def _begin_cmd(self) -> asyncio.Lock:
-        return asyncio.Lock()
+        # Stay Connected toggle: when True (default), HA maintains a
+        # persistent BLE connection and the coordinator polls every 5s.
+        # When False, HA disconnects immediately after each command, freeing
+        # the BLE link so the user's smartphone app can connect.
+        self._stay_connected: bool = True
 
-    async def _end_cmd(self):
-        await asyncio.sleep(0.75)
+        # Register library callbacks
+        self._controller.register_status_callback(self._on_library_status_update)
+        self._controller.register_disconnect_callback(self._on_library_disconnect)
 
-    def _on_status_update(self, sender, data: WalkingPadCurStatus) -> None:
-        """Update current state."""
+    # --- Status mapping ---
 
-        status: WalkingPadStatus = {
-            "belt_state": (
-                BeltState(data.belt_state)
-                if data.belt_state in iter(BeltState)
-                else BeltState.UNKNOWN
-            ),
-            "speed": data.speed / 10,
-            "mode": WalkingPadMode(data.manual_mode),
-            "session_distance": data.dist * 10,
-            "session_running_time": data.time,
-            "session_steps": data.steps,
-            "status_timestamp": data.rtime,
+    def _on_library_status_update(self, status: TreadmillStatus) -> None:
+        """Map library TreadmillStatus to HA WalkingPadStatus and fire callbacks."""
+        belt_state = (
+            BeltState(status.belt_state)
+            if status.belt_state in iter(BeltState)
+            else BeltState.UNKNOWN
+        )
+
+        # Map library OperatingMode int to HA WalkingPadMode enum
+        try:
+            mode = WalkingPadMode(status.mode)
+        except ValueError:
+            mode = WalkingPadMode.MANUAL
+
+        ha_status: WalkingPadStatus = {
+            "belt_state": belt_state,
+            "speed": status.speed,
+            "mode": mode,
+            "session_distance": status.distance,
+            "session_running_time": status.duration,
+            "session_steps": status.steps,
+            "session_calories": status.calories,
+            "status_timestamp": status.timestamp,
         }
+        self._fire_callbacks(ha_status)
 
-        if len(self._callbacks) > 0:
-            for callback in self._callbacks:
+    def _on_library_disconnect(self) -> None:
+        """Handle disconnect from the library controller."""
+        _LOGGER.warning("Device disconnected, marking as not connected")
+        self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+
+    def _fire_callbacks(self, status: WalkingPadStatus) -> None:
+        """Fire all registered status callbacks."""
+        for callback in self._callbacks:
+            try:
                 callback(status)
+            except Exception:
+                _LOGGER.exception("Error in status callback")
 
     def register_status_callback(self, callback) -> None:
         """Register a status callback."""
         self._callbacks.append(callback)
 
+    # --- Properties ---
+
     @property
     def mac(self):
         """Mac address."""
-        return self._ble_device.address
+        return self._controller.address
 
     @property
     def name(self):
         """Name."""
-        return self._name
+        return self._controller.name
+
+    @property
+    def protocol(self):
+        """The detected protocol type."""
+        return self._controller.protocol
 
     @property
     def connection_status(self) -> WalkingPadConnectionStatus:
@@ -90,107 +138,182 @@ class WalkingPad:
         """Boolean property to check if the device is connected."""
         return self._connection_status == WalkingPadConnectionStatus.CONNECTED
 
+    @property
+    def ble_lock(self) -> asyncio.Lock:
+        """BLE operation lock for multi-step command sequences."""
+        return self._ble_lock
+
+    @property
+    def stay_connected(self) -> bool:
+        """Whether HA should maintain a persistent BLE connection."""
+        return self._stay_connected
+
+    @stay_connected.setter
+    def stay_connected(self, value: bool) -> None:
+        """Set the stay_connected preference."""
+        self._stay_connected = value
+        _LOGGER.info("Stay connected set to %s", value)
+
+    async def disconnect_after_command(self) -> None:
+        """Disconnect immediately if stay_connected is disabled."""
+        if not self._stay_connected:
+            _LOGGER.debug("Stay connected disabled, disconnecting after command")
+            await self.disconnect()
+
+    # --- Connection ---
+
     async def connect(self) -> None:
-        """Connect the device."""
-        lock = self._begin_cmd()
+        """Connect to the device."""
         if self._connection_status == WalkingPadConnectionStatus.CONNECTING:
             _LOGGER.info("Already connecting to WalkingPad")
             return
-        _LOGGER.info("Connecting to WalkingPad")
-        async with lock:
-            self._connection_status = WalkingPadConnectionStatus.CONNECTING
-            try:
-                await self._controller.run(self._ble_device)
-                self._connection_status = WalkingPadConnectionStatus.CONNECTED
-            except (BleakError, TimeoutError) as err:
-                _LOGGER.warning("Unable to connect to WalkingPad : %s", err)
-                self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.warning("Unable to connect to WalkingPad")
-                self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
-            await self._end_cmd()
+
+        self._connection_status = WalkingPadConnectionStatus.CONNECTING
+
+        try:
+            await self._controller.connect()
+            self._connection_status = WalkingPadConnectionStatus.CONNECTED
+            _LOGGER.info(
+                "Connected to WalkingPad via %s protocol",
+                self._controller.protocol.value,
+            )
+        except (BleakError, TimeoutError) as err:
+            _LOGGER.warning("Unable to connect to WalkingPad: %s", err)
+            self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+        except Exception:
+            _LOGGER.exception("Unable to connect to WalkingPad")
+            self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
 
     async def disconnect(self) -> None:
         """Disconnect the device."""
         if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
             return
-        lock = self._begin_cmd()
-        async with lock:
-            try:
-                await self._controller.disconnect()
-            finally:
-                self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
-            await self._end_cmd()
+        try:
+            await self._controller.disconnect()
+        except Exception:
+            _LOGGER.exception("Error during disconnect")
+        finally:
+            self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+
+    # --- Commands ---
 
     async def update_state(self) -> None:
-        """Update device state."""
-        # Grab the lock so we don't run while another command is running
-        if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
-            await self.connect()
-        lock = self._begin_cmd()
-        async with lock:
+        """Update device state by requesting current status."""
+        async with self._ble_lock:
+            if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
+                await self.connect()
+
             if not self.connected:
                 return
+
             try:
-                await self._controller.ask_stats()
-                # Skip callback so we don't reset debouncer
+                await self._controller.update_state()
+                # If the library detects the backend is disconnected, it sets
+                # connected=False. Sync our status.
+                if not self._controller.connected:
+                    self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
             except BleakError as err:
-                _LOGGER.warning("Bluetooth error : %s", err)
+                _LOGGER.warning("Bluetooth error during state update: %s", err)
                 self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
 
     async def start_belt(self) -> None:
         """Start the belt."""
+        async with self._ble_lock:
+            await self._start_belt_unlocked()
+
+    async def _start_belt_unlocked(self) -> None:
+        """Start the belt (caller must hold _ble_lock)."""
         if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
             await self.connect()
-        lock = self._begin_cmd()
-        async with lock:
-            if not self.connected:
-                return
-            try:
-                await self._controller.start_belt()
-            except BleakError as err:
-                _LOGGER.warning("Bluetooth error : %s", err)
-                self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+        if not self.connected:
+            return
+
+        try:
+            await self._controller.start()
+        except BleakError as err:
+            _LOGGER.warning("Bluetooth error: %s", err)
+            self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+        finally:
+            await self.disconnect_after_command()
 
     async def stop_belt(self) -> None:
-        """Start the belt."""
-        if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
-            await self.connect()
-        lock = self._begin_cmd()
-        async with lock:
+        """Stop the belt."""
+        async with self._ble_lock:
+            if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
+                await self.connect()
             if not self.connected:
                 return
+
             try:
-                await self._controller.stop_belt()
+                await self._controller.stop()
             except BleakError as err:
-                _LOGGER.warning("Bluetooth error : %s", err)
+                _LOGGER.warning("Bluetooth error: %s", err)
                 self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+            finally:
+                await self.disconnect_after_command()
 
     async def set_speed(self, speed: float) -> None:
         """Set the belt speed in km/h."""
-        if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
-            await self.connect()
-        lock = self._begin_cmd()
-        async with lock:
+        async with self._ble_lock:
+            if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
+                await self.connect()
             if not self.connected:
                 return
+
             try:
-                speed_tenths = int(speed * 10)
-                await self._controller.change_speed(speed_tenths)
+                await self._controller.set_speed(speed)
             except BleakError as err:
-                _LOGGER.warning("Bluetooth error : %s", err)
+                _LOGGER.warning("Bluetooth error: %s", err)
                 self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+            finally:
+                await self.disconnect_after_command()
 
     async def switch_mode(self, mode: WalkingPadMode) -> None:
         """Switch the WalkingPad mode."""
+        async with self._ble_lock:
+            await self._switch_mode_unlocked(mode)
+
+    async def _switch_mode_unlocked(self, mode: WalkingPadMode) -> None:
+        """Switch the WalkingPad mode (caller must hold _ble_lock)."""
         if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
             await self.connect()
-        lock = self._begin_cmd()
-        async with lock:
-            if not self.connected:
-                return
-            try:
-                await self._controller.switch_mode(mode.value)
-            except BleakError as err:
-                _LOGGER.warning("Bluetooth error : %s", err)
-                self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+        if not self.connected:
+            return
+
+        try:
+            # Map HA WalkingPadMode to library OperatingMode
+            lib_mode = OperatingMode(mode.value)
+            await self._controller.switch_mode(lib_mode)
+        except BleakError as err:
+            _LOGGER.warning("Bluetooth error: %s", err)
+            self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+        finally:
+            await self.disconnect_after_command()
+
+    async def start_belt_in_mode(self, mode: WalkingPadMode) -> None:
+        """Switch mode and start the belt atomically.
+
+        Holds the BLE lock across the entire sequence so coordinator polls
+        cannot interleave between switch_mode and start_belt.
+        """
+        async with self._ble_lock:
+            await self._switch_mode_unlocked(mode)
+            await asyncio.sleep(1.5)
+            await self._start_belt_unlocked()
+
+    # --- Speed properties (delegated to library) ---
+
+    @property
+    def min_speed(self) -> float:
+        """Minimum speed in km/h."""
+        return self._controller.min_speed
+
+    @property
+    def max_speed(self) -> float:
+        """Maximum speed in km/h."""
+        return self._controller.max_speed
+
+    @property
+    def speed_increment(self) -> float:
+        """Speed step size in km/h."""
+        return self._controller.speed_increment

--- a/custom_components/king_smith/walkingpad.py
+++ b/custom_components/king_smith/walkingpad.py
@@ -317,3 +317,8 @@ class WalkingPad:
     def speed_increment(self) -> float:
         """Speed step size in km/h."""
         return self._controller.speed_increment
+
+    @property
+    def firmware_version(self) -> str:
+        """Firmware version reported by the device (FTMS only; empty otherwise)."""
+        return self._controller.firmware_version

--- a/custom_components/king_smith/walkingpad.py
+++ b/custom_components/king_smith/walkingpad.py
@@ -55,6 +55,7 @@ class WalkingPad:
         """Create a WalkingPad object."""
         self._controller = WalkingPadController(ble_device=ble_device, name=name)
         self._callbacks = []
+        self._disconnect_callbacks = []
         self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
 
         # BLE operation lock — serialises all BLE operations so coordinator
@@ -102,6 +103,8 @@ class WalkingPad:
             "session_running_time": status.duration,
             "session_steps": status.steps,
             "session_calories": status.calories,
+            "session_calories_per_hour": status.calories_per_hour,
+            "heart_rate": status.heart_rate,
             "training_status": status.training_status,
             "last_fm_event": status.last_fm_event,
             "status_timestamp": status.timestamp,
@@ -112,6 +115,7 @@ class WalkingPad:
         """Handle disconnect from the library controller."""
         _LOGGER.warning("Device disconnected, marking as not connected")
         self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+        self._fire_disconnect_callbacks()
 
     def _fire_callbacks(self, status: WalkingPadStatus) -> None:
         """Fire all registered status callbacks."""
@@ -121,9 +125,21 @@ class WalkingPad:
             except Exception:
                 _LOGGER.exception("Error in status callback")
 
+    def _fire_disconnect_callbacks(self) -> None:
+        """Fire all registered disconnect callbacks."""
+        for callback in self._disconnect_callbacks:
+            try:
+                callback()
+            except Exception:
+                _LOGGER.exception("Error in disconnect callback")
+
     def register_status_callback(self, callback) -> None:
         """Register a status callback."""
         self._callbacks.append(callback)
+
+    def register_disconnect_callback(self, callback) -> None:
+        """Register a callback fired when the BLE link drops."""
+        self._disconnect_callbacks.append(callback)
 
     # --- Properties ---
 

--- a/custom_components/king_smith/walkingpad.py
+++ b/custom_components/king_smith/walkingpad.py
@@ -90,6 +90,8 @@ class WalkingPad:
             "session_running_time": status.duration,
             "session_steps": status.steps,
             "session_calories": status.calories,
+            "training_status": status.training_status,
+            "last_fm_event": status.last_fm_event,
             "status_timestamp": status.timestamp,
         }
         self._fire_callbacks(ha_status)

--- a/custom_components/king_smith/walkingpad.py
+++ b/custom_components/king_smith/walkingpad.py
@@ -17,12 +17,20 @@ from enum import Enum, unique
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
+import walkingpad_controller.controller as _wpc_controller
 from walkingpad_controller import (
     BeltState,
     OperatingMode,
     TreadmillStatus,
     WalkingPadController,
 )
+
+# The library does its own 5-attempt internal retry on connect() with 3 s
+# between attempts (~16 s wasted on a single "no-slot" cycle). Our coordinator
+# already runs a reconnect loop with backoff, so the library's retry layer
+# just slows down the time-to-first-success when the BLE stack briefly has no
+# slot. One internal attempt is enough; our loop handles retries.
+_wpc_controller.MAX_CONNECT_RETRIES = 1
 
 from .const import WalkingPadMode, WalkingPadStatus
 
@@ -251,8 +259,10 @@ class WalkingPad:
         # idle-disconnect — we're about to use the link.
         self._cancel_idle_disconnect()
 
+        if self._connection_status == WalkingPadConnectionStatus.CONNECTED:
+            return
         if self._connection_status == WalkingPadConnectionStatus.CONNECTING:
-            _LOGGER.info("Already connecting to WalkingPad")
+            _LOGGER.debug("Already connecting to WalkingPad")
             return
 
         self._connection_status = WalkingPadConnectionStatus.CONNECTING
@@ -270,6 +280,12 @@ class WalkingPad:
         except Exception:
             _LOGGER.exception("Unable to connect to WalkingPad")
             self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+        finally:
+            # If we exit through CancelledError (BaseException, not Exception)
+            # the except clauses don't run and status would stick in CONNECTING
+            # forever, jamming all subsequent reconnects.
+            if self._connection_status == WalkingPadConnectionStatus.CONNECTING:
+                self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
 
     async def disconnect(self) -> None:
         """Disconnect the device."""
@@ -285,11 +301,13 @@ class WalkingPad:
     # --- Commands ---
 
     async def update_state(self) -> None:
-        """Update device state by requesting current status."""
-        async with self._ble_lock:
-            if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
-                await self.connect()
+        """Update device state by requesting current status.
 
+        Polling does not initiate connects — the coordinator's reconnect
+        loop is the sole source of (re)connection attempts, so polling
+        and the loop don't race and create back-to-back library cycles.
+        """
+        async with self._ble_lock:
             if not self.connected:
                 return
 
@@ -324,7 +342,12 @@ class WalkingPad:
             await self.disconnect_after_command()
 
     async def stop_belt(self) -> None:
-        """Stop the belt."""
+        """Stop the belt — full session end. Resets counters.
+
+        Most UI flows should call ``pause_belt()`` instead; that matches
+        the phone-app behaviour where the user's stop button preserves
+        time/distance/steps across the pause/resume cycle.
+        """
         async with self._ble_lock:
             if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
                 await self.connect()
@@ -333,6 +356,28 @@ class WalkingPad:
 
             try:
                 await self._controller.stop()
+            except BleakError as err:
+                _LOGGER.warning("Bluetooth error: %s", err)
+                self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+            finally:
+                await self.disconnect_after_command()
+
+    async def pause_belt(self) -> None:
+        """Pause the belt — session stays live, counters preserved.
+
+        Sends FTMS ``STOP_OR_PAUSE`` with the PAUSE param, matching what
+        KS Fit and the physical remote do when the user presses stop.
+        A subsequent ``start_belt()`` resumes the session and continues
+        accumulating time/distance/steps from where it left off.
+        """
+        async with self._ble_lock:
+            if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
+                await self.connect()
+            if not self.connected:
+                return
+
+            try:
+                await self._controller.pause()
             except BleakError as err:
                 _LOGGER.warning("Bluetooth error: %s", err)
                 self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED

--- a/custom_components/king_smith/walkingpad.py
+++ b/custom_components/king_smith/walkingpad.py
@@ -115,6 +115,8 @@ class WalkingPad:
             "heart_rate": status.heart_rate,
             "training_status": status.training_status,
             "last_fm_event": status.last_fm_event,
+            "vibration_level": getattr(status, "vibration_level", 0),
+            "incline": getattr(status, "incline", 0),
             "status_timestamp": status.timestamp,
         }
         self._fire_callbacks(ha_status)
@@ -394,6 +396,48 @@ class WalkingPad:
 
             try:
                 await self._controller.set_speed(speed)
+            except BleakError as err:
+                _LOGGER.warning("Bluetooth error: %s", err)
+                self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+            finally:
+                await self.disconnect_after_command()
+
+    async def set_vibration(self, level: int) -> None:
+        """Set the vibration level (0 = off, 1-4).
+
+        Sperax / WLT6200 devices only. On the P3 Max the belt and the
+        vibration motor are mutually exclusive — turning vibration on stops
+        the belt.
+        """
+        async with self._ble_lock:
+            if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
+                await self.connect()
+            if not self.connected:
+                return
+
+            try:
+                await self._controller.set_vibration(level)
+            except BleakError as err:
+                _LOGGER.warning("Bluetooth error: %s", err)
+                self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
+            finally:
+                await self.disconnect_after_command()
+
+    async def set_incline(self, level: int) -> None:
+        """Set the incline level (0 = flat .. 10 = max).
+
+        Sperax / WLT6200 devices only. Incline rides inside the run command,
+        so the library only applies it while the belt is moving; when stopped
+        it caches the target and applies it on the next start.
+        """
+        async with self._ble_lock:
+            if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
+                await self.connect()
+            if not self.connected:
+                return
+
+            try:
+                await self._controller.set_incline(level)
             except BleakError as err:
                 _LOGGER.warning("Bluetooth error: %s", err)
                 self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED


### PR DESCRIPTION
## Summary

Add support for KingSmith treadmills that use the standard **Bluetooth FTMS (Fitness Machine Service)** protocol instead of the legacy WiLink protocol. This enables newer KingSmith devices (e.g. KS-Z1D, A1PRO, P1E) that advertise BLE names starting with `KS-HD-*` to work with this integration.

The integration remains **fully backward-compatible** with existing WiLink devices.

All protocol logic (FTMS + WiLink) lives in the standalone [walkingpad-controller](https://pypi.org/project/walkingpad-controller/) library on PyPI, following HA's [recommended architecture](https://developers.home-assistant.io/docs/api_lib_index/) for separating device communication from the integration.

## What's Included (8 commits)

### Core FTMS Support
- **`walkingpad.py`** — Thin wrapper around `walkingpad-controller`'s `WalkingPadController`. Auto-detects protocol from BLE device name (`KS-HD-*` → FTMS) or service UUIDs on first connection, delegates to the library
- **`const.py`** — Re-exports `BeltState` and `ProtocolType` from the library, added `session_calories` field to `WalkingPadStatus`

### Sensors & Entities
- **Steps sensor** — Available for both protocols (FTMS uses pressure-sensor based step counter from KingSmith extension bytes; WiLink uses existing step count)
- **Calories sensor** — FTMS-only, from FTMS Expended Energy field
- **Speed number entity** — Uses dynamic min/max/step from FTMS device capabilities
- **Stay Connected switch** — Per-device toggle to control persistent BLE connection (see below)

### Stay Connected Switch (new feature)
BLE is exclusive — only one client can connect at a time. The new **"Stay connected"** switch lets users toggle whether HA maintains a persistent connection:
- **ON (default):** Normal behavior — polls every 5s, sensors update live
- **OFF:** HA disconnects immediately, freeing BLE for the smartphone app (KS Fit). Commands still work via connect→send→disconnect. Sensors go stale.
- State persists across HA restarts via `RestoreEntity`

### Device Linking (fixes #116)
All entities now provide `DeviceInfo`, so HA groups them under a single device with proper device-linked naming.

### BLE Discovery
Added `KS-HD-*` to the `bluetooth` local_name patterns in `manifest.json` for auto-discovery.

## Technical Details

### FTMS Protocol (reverse-engineered from KS Fit app)
- Service UUID: `0x1826`
- Control Point: Request Control → Start/Resume → Set Target Speed → Stop
- Treadmill Data (0x2ACD): 17-byte packets with flags `0x2484`, including KingSmith proprietary extension (3 bytes: uint16 LE step count + 1 zero byte)
- Cold start requires START_OR_RESUME before SET_TARGET_SPEED; speed commands are silently ignored for several seconds after cold start (retry logic in the library handles this)

### Architecture
Protocol communication is handled by [walkingpad-controller](https://github.com/mcdax/walkingpad-controller), a standalone Python library on PyPI that supports both FTMS (via `bleak`) and WiLink (via `ph4-walkingpad`) behind a unified API. The integration adds only HA-specific concerns: entities, coordinator, config flow, and the Stay Connected toggle.

### Tested On
- KingSmith KS-Z1D (BLE name: `KS-HD-Z1D`)
- Speed range: 1.0–6.0 km/h, increment 0.1 km/h

## Files Changed
| File | Change |
|------|--------|
| `walkingpad.py` | Rewritten as thin wrapper around `walkingpad-controller` library |
| `coordinator.py` | Stay connected guard in polling + toggle method |
| `switch.py` | Stay Connected switch + DeviceInfo on belt switches |
| `sensor.py` | Steps in common sensors, calories for FTMS, DeviceInfo |
| `number.py` | Dynamic speed limits from FTMS capabilities, DeviceInfo |
| `const.py` | Re-exports from library, session_calories |
| `translations/en.json` | Calories + Stay connected labels |
| `manifest.json` | KS-HD-* pattern, `walkingpad-controller` dependency, version bump |
| `README.md` | Updated documentation |

**Net diff vs upstream: +443 / -165 lines across 9 files**

Closes #116
