### PR TITLE
Refactor: Group entities under single device

### DIFF
--- a/custom_components/king_smith/__init__.py
+++ b/custom_components/king_smith/__init__.py
@@ -10,6 +10,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_MAC, CONF_NAME, DOMAIN
 from .coordinator import WalkingPadCoordinator
@@ -23,6 +25,7 @@ class WalkingPadIntegrationData(TypedDict):
 
     device: WalkingPad
     coordinator: WalkingPadCoordinator
+    device_entry: DeviceEntry
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,9 +65,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     walkingpad_device = WalkingPad(name, ble_device)
     coordinator = WalkingPadCoordinator(hass, walkingpad_device)
 
+    # Obtener nombre del dispositivo BLE
+    ble_name = ble_device.name or "WalkingPad"
+    
+    # Crear el dispositivo en el registro de dispositivos
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections={(dr.CONNECTION_BLUETOOTH, address)},
+        identifiers={(DOMAIN, address)},
+        name=name or ble_name,
+        manufacturer="King Smith",
+        model=ble_name or "WalkingPad A1 Pro",
+        hw_version=None,
+        sw_version=None,
+    )
+
     integration_data: WalkingPadIntegrationData = {
         "device": walkingpad_device,
         "coordinator": coordinator,
+        "device_entry": device_entry,
     }
     hass.data[DOMAIN][entry.entry_id] = integration_data
 

--- a/custom_components/king_smith/number.py
+++ b/custom_components/king_smith/number.py
@@ -5,6 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfSpeed
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -65,6 +66,17 @@ class WalkingPadSpeedNumberEntity(
         """Initialize the speed number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.walkingpad_device.mac}-{NUMBER_KEY}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        ble_name = self.coordinator.walkingpad_device._ble_device.name or "WalkingPad"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.walkingpad_device.mac)},
+            name=self.coordinator.walkingpad_device.name,
+            manufacturer="King Smith",
+            model=ble_name or "WalkingPad A1 Pro",
+        )
 
     @property
     def native_value(self) -> float:

--- a/custom_components/king_smith/sensor.py
+++ b/custom_components/king_smith/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import WalkingPadIntegrationData
 from .const import DOMAIN, BeltState, WalkingPadMode, WalkingPadStatus
@@ -150,6 +151,17 @@ class WalkingPadSensor(
         self.entity_description = entity_description
         self._attr_unique_id = (
             f"{coordinator.walkingpad_device.mac}-{self.entity_description.key}"
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        ble_name = self.coordinator.walkingpad_device._ble_device.name or "WalkingPad"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.walkingpad_device.mac)},
+            name=self.coordinator.walkingpad_device.name,
+            manufacturer="King Smith",
+            model=ble_name or "WalkingPad A1 Pro",
         )
 
     @property

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -12,6 +12,7 @@ from homeassistant.components.switch import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import WalkingPadIntegrationData
@@ -88,6 +89,17 @@ class WalkingPadBeltSwitchBase(SwitchEntity, ABC):
             f"{coordinator.walkingpad_device.mac}-{self.entity_description.key}"
         )
         super().__init__()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        ble_name = self.coordinator.walkingpad_device._ble_device.name or "WalkingPad"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.walkingpad_device.mac)},
+            name=self.coordinator.walkingpad_device.name,
+            manufacturer="King Smith",
+            model=ble_name or "WalkingPad A1 Pro",
+        )
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/king_smith/walkingpad.py
+++ b/custom_components/king_smith/walkingpad.py
@@ -35,6 +35,26 @@ class WalkingPad:
         self._callbacks = []
         self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
         self._register_controller_callbacks()
+        
+        # Log de depuración
+        self._log_device_info()
+
+    def _log_device_info(self):
+        """Log device information for debugging."""
+        _LOGGER.debug("=== WalkingPad Device Info ===")
+        _LOGGER.debug("Name: %s", self._ble_device.name)
+        _LOGGER.debug("Address: %s", self._ble_device.address)
+        
+        # Intentar acceder a atributos disponibles
+        attrs_to_check = ['name', 'address', 'rssi', 'tx_power', 'details', 'advertisement_data', 'metadata']
+        for attr in attrs_to_check:
+            if hasattr(self._ble_device, attr):
+                try:
+                    value = getattr(self._ble_device, attr)
+                    if not callable(value):
+                        _LOGGER.debug("  %s: %s", attr, value)
+                except Exception as e:
+                    _LOGGER.debug("  %s: Error - %s", attr, e)
 
     def _register_controller_callbacks(self):
         self._controller.handler_cur_status = self._on_status_update
@@ -153,7 +173,7 @@ class WalkingPad:
                 self._connection_status = WalkingPadConnectionStatus.NOT_CONNECTED
 
     async def stop_belt(self) -> None:
-        """Start the belt."""
+        """Stop the belt."""
         if self._connection_status == WalkingPadConnectionStatus.NOT_CONNECTED:
             await self.connect()
         lock = self._begin_cmd()


### PR DESCRIPTION
## Description
Groups all integration entities under a single BLE device for better organization in Home Assistant.

## Changes
- All entities are now linked to the main BLE device
- Device model is dynamically read from BLE advertisement data
- Improved entity organization and hierarchy

## Type of change
- [x] Enhancement
- [ ] Bug fix
- [ ] New feature